### PR TITLE
Add Codex platform support to capy setup

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -1,0 +1,73 @@
+# capy — MANDATORY routing rules
+
+You have capy MCP tools available. These rules are NOT optional — they protect your context window from flooding. A single unrouted command can dump 56 KB into context and waste the entire session.
+
+## BLOCKED commands — do NOT attempt these
+
+### curl / wget — BLOCKED
+Any Bash command containing `curl` or `wget` is intercepted and replaced with an error message. Do NOT retry.
+Instead use:
+- `capy_fetch_and_index(url, source)` to fetch and index web pages
+- `capy_execute(language: "javascript", code: "const r = await fetch(...)")` to run HTTP calls in sandbox
+
+### Inline HTTP — BLOCKED
+Any Bash command containing `fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, or `http.request(` is intercepted and replaced with an error message. Do NOT retry with Bash.
+Instead use:
+- `capy_execute(language, code)` to run HTTP calls in sandbox — only stdout enters context
+
+### WebFetch — BLOCKED
+WebFetch calls are denied entirely. The URL is extracted and you are told to use `capy_fetch_and_index` instead.
+Instead use:
+- `capy_fetch_and_index(url, source)` then `capy_search(queries)` to query the indexed content
+
+## REDIRECTED tools — use sandbox equivalents
+
+### Bash (>20 lines output)
+Bash is ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`, and other short-output commands.
+For everything else, use:
+- `capy_batch_execute(commands, queries)` — run multiple commands + search in ONE call
+- `capy_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
+
+### Read vs capy_execute_file
+
+**Default to `Read`.** It's cheap for normal-sized files, shows you actual content (not just patterns you knew to grep for), and is required if an Edit follows. Use `offset`/`limit` to scope large files.
+
+**Reach for `capy_execute_file` only when ALL of these hold:**
+1. The file is genuinely large (10k+ lines, or measured >100 KB), AND
+2. You want a *derived answer* (count, stats, extracted pattern, structural summary) — not the content itself, AND
+3. You can write the exact grep/awk/script upfront. If you'd struggle to, you don't know enough yet — just `Read`.
+
+**Anti-patterns — do NOT do this:**
+- `capy_execute_file` to grep section headings, then `Read` the file anyway to Edit it. The Read makes the capy call pure overhead.
+- `capy_execute_file` on a code file to "explore structure." Use Serena's `get_symbols_overview` / `find_symbol` — purpose-built and cheaper.
+- `capy_execute_file` on a small/medium file (<2k lines) "to save context." The savings don't exist; you're adding latency.
+
+**Rule of thumb:** capy saves context only when content would otherwise enter context. If you're going to `Read` it anyway (for Edit, for line citations, for follow-ups), capy adds nothing.
+
+### Grep (large results)
+Grep results can flood context. Use `capy_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.
+
+## Tool selection hierarchy
+
+1. **GATHER**: `capy_batch_execute(commands, queries)` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls.
+2. **FOLLOW-UP**: `capy_search(queries: ["q1", "q2", ...])` — Query indexed content. Pass ALL questions as array in ONE call.
+3. **PROCESSING**: `capy_execute(language, code)` | `capy_execute_file(path, language, code)` — Sandbox execution. Only stdout enters context.
+4. **WEB**: `capy_fetch_and_index(url, source)` then `capy_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
+5. **INDEX**: `capy_index(content, source)` — Store content in FTS5 knowledge base for later search.
+
+## Subagent routing
+
+When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.
+
+## Output constraints
+
+- Keep responses under 500 words.
+- Write artifacts (code, configs, PRDs) to FILES — never return them as inline text. Return only: file path + 1-line description.
+- When indexing content, use descriptive source labels so others can `capy_search(source: "label")` later.
+
+## capy commands
+
+| Command | Action |
+|---------|--------|
+| `capy stats` | Call the `capy_stats` MCP tool and display the full output verbatim |
+| `capy doctor` | Call the `capy_doctor` MCP tool and display as checklist |

--- a/.codex/scripts/session-start.sh
+++ b/.codex/scripts/session-start.sh
@@ -109,7 +109,7 @@ Task tracking uses simple markdown files co-located with feature design docs:
 The full workflow: `design` (design + create tasks) → `review-design` → `implement` (execute tasks + `review-code`/`test`/`document` at the end of each task) → `test` (verify) → `document` (document)
 EOF
 
-AGENTS_CAPY_MD=$(cat "${REPO_ROOT}/.claude/capy/CLAUDE.md")
+AGENTS_CAPY_MD=$(cat "${REPO_ROOT}/.capy/AGENTS.md")
 
 CONTEXT="${CONTEXT}
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ homebrew/
 .capy/**
 
 !.capy
+!.capy/AGENTS.md
 !.capy/knowledge.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,4 +18,4 @@ It's a port of `context-mode` project written in Go, aiming to utilize Go's feat
 
 # capy — MANDATORY routing rules
 
-@.claude/capy/CLAUDE.md
+@.capy/AGENTS.md

--- a/cmd/capy/setup.go
+++ b/cmd/capy/setup.go
@@ -22,36 +22,54 @@ func newSetupCmd() *cobra.Command {
 			}
 
 			binaryPath, _ := cmd.Flags().GetString("binary")
-
 			p, _ := cmd.Flags().GetString("platform")
-			if p != "claude-code" {
-				return fmt.Errorf("unsupported platform: %s (only claude-code is supported)", p)
-			}
 
-			local, _ := cmd.Flags().GetBool("local")
-			project, _ := cmd.Flags().GetBool("project")
+			setupClaude := p == "" || p == "claude-code"
+			setupCodex := p == "" || p == "codex"
 
-			target, err := resolveSettingsTarget(local, project)
-			if err != nil {
-				return err
+			if !setupClaude && !setupCodex {
+				return fmt.Errorf("unsupported platform: %s (supported: claude-code, codex)", p)
 			}
 
 			fmt.Printf("capy: setting up for project %s\n", projectDir)
 
-			if err := platform.SetupClaudeCode(binaryPath, projectDir, target); err != nil {
-				return fmt.Errorf("setup failed: %w", err)
+			if setupClaude {
+				local, _ := cmd.Flags().GetBool("local")
+				project, _ := cmd.Flags().GetBool("project")
+
+				target, err := resolveSettingsTarget(local, project)
+				if err != nil {
+					return err
+				}
+
+				if err := platform.SetupClaudeCode(binaryPath, projectDir, target); err != nil {
+					return fmt.Errorf("Claude Code setup failed: %w", err)
+				}
+
+				fmt.Println("capy: Claude Code setup complete")
+				fmt.Printf("  - hooks registered in .claude/%s\n", target.SettingsFilename())
+				fmt.Println("  - MCP server registered in .mcp.json")
+				fmt.Println("  - routing instructions written to .capy/AGENTS.md")
+				fmt.Println("  - .capy/** added to .gitignore")
 			}
 
-			fmt.Println("capy: setup complete")
-			fmt.Printf("  - hooks registered in .claude/%s\n", target.SettingsFilename())
-			fmt.Println("  - MCP server registered in .mcp.json")
-			fmt.Println("  - routing instructions written to .claude/capy/CLAUDE.md")
-			fmt.Println("  - .capy/** added to .gitignore")
+			if setupCodex {
+				if err := platform.SetupCodex(binaryPath, projectDir); err != nil {
+					return fmt.Errorf("Codex setup failed: %w", err)
+				}
+
+				fmt.Println("capy: Codex setup complete")
+				fmt.Println("  - MCP server registered in .codex/config.toml")
+				fmt.Println("  - routing instructions written to .capy/AGENTS.md")
+				fmt.Println("  - wrapper script written to .codex/scripts/capy.sh")
+				fmt.Println("  - .capy/** added to .gitignore")
+			}
+
 			fmt.Println("\nRun `capy doctor` to verify the installation.")
 			return nil
 		},
 	}
-	cmd.Flags().String("platform", "claude-code", "target platform")
+	cmd.Flags().String("platform", "", "target platform (claude-code, codex); default: both")
 	cmd.Flags().String("binary", "", "path to capy binary")
 	cmd.Flags().Bool("local", false, "write hooks to .claude/settings.local.json (personal, not committed)")
 	cmd.Flags().Bool("project", false, "write hooks to .claude/settings.json (shared, synced across repos)")

--- a/internal/platform/setup.go
+++ b/internal/platform/setup.go
@@ -14,6 +14,9 @@ import (
 // capyWrapperRelPath is the project-relative path to the portable capy wrapper script.
 const capyWrapperRelPath = ".claude/scripts/capy.sh"
 
+// codexWrapperRelPath is the project-relative path to the capy wrapper for Codex.
+const codexWrapperRelPath = ".codex/scripts/capy.sh"
+
 // capyWrapperScript is the content of the portable wrapper script.
 // It searches known installation paths for the capy binary and execs the first
 // one found, making configs portable across machines and platforms.
@@ -40,14 +43,19 @@ jq -n --arg reason "capy binary not found" \
 exit 0
 `
 
-// writeCapyWrapper creates the portable wrapper script at .claude/scripts/capy.sh.
-func writeCapyWrapper(projectDir string) error {
-	scriptsDir := filepath.Join(projectDir, ".claude", "scripts")
+// writeWrapperScript creates the portable wrapper script at the given relative path.
+func writeWrapperScript(projectDir, relPath string) error {
+	scriptsDir := filepath.Join(projectDir, filepath.Dir(relPath))
 	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
 		return fmt.Errorf("creating scripts directory: %w", err)
 	}
-	wrapperPath := filepath.Join(projectDir, capyWrapperRelPath)
+	wrapperPath := filepath.Join(projectDir, relPath)
 	return os.WriteFile(wrapperPath, []byte(capyWrapperScript), 0o755)
+}
+
+// writeCapyWrapper creates the portable wrapper script at .claude/scripts/capy.sh.
+func writeCapyWrapper(projectDir string) error {
+	return writeWrapperScript(projectDir, capyWrapperRelPath)
 }
 
 // SetupClaudeCode configures capy for a Claude Code project.
@@ -77,7 +85,7 @@ func SetupClaudeCode(binaryPath, projectDir string, target SettingsTarget) error
 		return fmt.Errorf("creating .capy directory: %w", err)
 	}
 
-	// 3. Create .claude/ directory (needed for settings.json)
+	// 3. Create .claude/ directory (needed for settings.json and scripts)
 	claudeDir := filepath.Join(projectDir, ".claude")
 	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		return fmt.Errorf("creating .claude directory: %w", err)
@@ -113,15 +121,22 @@ func SetupClaudeCode(binaryPath, projectDir string, target SettingsTarget) error
 		return fmt.Errorf("merging MCP config: %w", err)
 	}
 
-	// 7. Write routing instructions to .claude/capy/CLAUDE.md and import from root CLAUDE.md
-	claudeMDPath := filepath.Join(projectDir, "CLAUDE.md")
-	if err := writeRoutingInstructions(claudeDir, claudeMDPath); err != nil {
-		return fmt.Errorf("updating routing instructions: %w", err)
+	// 7. Write routing instructions to .capy/AGENTS.md and import from root CLAUDE.md
+	if err := writeAgentsFile(projectDir); err != nil {
+		return fmt.Errorf("writing routing instructions: %w", err)
 	}
+	claudeMDPath := filepath.Join(projectDir, "CLAUDE.md")
+	if err := ensureClaudeMDImport(claudeMDPath); err != nil {
+		return fmt.Errorf("updating CLAUDE.md import: %w", err)
+	}
+	cleanupOldRoutingFile(projectDir)
 
-	// 8. Add .capy/** to .gitignore
+	// 8. Add .capy/** to .gitignore with exception for AGENTS.md
 	gitignorePath := filepath.Join(projectDir, ".gitignore")
 	if err := ensureGitignoreEntry(gitignorePath, ".capy/**"); err != nil {
+		return fmt.Errorf("updating .gitignore: %w", err)
+	}
+	if err := ensureGitignoreEntry(gitignorePath, "!.capy/AGENTS.md"); err != nil {
 		return fmt.Errorf("updating .gitignore: %w", err)
 	}
 
@@ -130,6 +145,65 @@ func SetupClaudeCode(binaryPath, projectDir string, target SettingsTarget) error
 		// Non-fatal: git hooks are a convenience, not a requirement
 		fmt.Fprintf(os.Stderr, "capy: warning: could not install pre-commit hook: %v\n", err)
 	}
+
+	return nil
+}
+
+// SetupCodex configures capy for a Codex project.
+// It detects the .codex directory, writes the portable wrapper script to
+// .codex/scripts/capy.sh, creates the .capy/ directory, and adds .capy/
+// to .gitignore.
+func SetupCodex(binaryPath, projectDir string) error {
+	// 1. Resolve binary path (validation only — configs use the portable wrapper)
+	if binaryPath == "" {
+		var err error
+		binaryPath, err = exec.LookPath("capy")
+		if err != nil {
+			binaryPath, err = os.Executable()
+			if err != nil {
+				return fmt.Errorf("capy binary not found in PATH; use --binary to specify location")
+			}
+		}
+	}
+
+	// 2. Create .codex/ directory
+	codexDir := filepath.Join(projectDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		return fmt.Errorf("creating .codex directory: %w", err)
+	}
+
+	// 3. Create .capy/ directory
+	capyDir := filepath.Join(projectDir, ".capy")
+	if err := os.MkdirAll(capyDir, 0o755); err != nil {
+		return fmt.Errorf("creating .capy directory: %w", err)
+	}
+
+	// 4. Write routing instructions to .capy/AGENTS.md
+	if err := writeAgentsFile(projectDir); err != nil {
+		return fmt.Errorf("writing routing instructions: %w", err)
+	}
+
+	// 5. Write portable wrapper script (.codex/scripts/capy.sh)
+	if err := writeWrapperScript(projectDir, codexWrapperRelPath); err != nil {
+		return fmt.Errorf("writing wrapper script: %w", err)
+	}
+
+	// 6. Merge MCP server into .codex/config.toml
+	configTomlPath := filepath.Join(projectDir, ".codex", "config.toml")
+	if err := mergeCodexMCPServer(configTomlPath); err != nil {
+		return fmt.Errorf("merging Codex MCP config: %w", err)
+	}
+
+	// 7. Add .capy/** to .gitignore with exception for AGENTS.md
+	gitignorePath := filepath.Join(projectDir, ".gitignore")
+	if err := ensureGitignoreEntry(gitignorePath, ".capy/**"); err != nil {
+		return fmt.Errorf("updating .gitignore: %w", err)
+	}
+	if err := ensureGitignoreEntry(gitignorePath, "!.capy/AGENTS.md"); err != nil {
+		return fmt.Errorf("updating .gitignore: %w", err)
+	}
+
+	cleanupOldRoutingFile(projectDir)
 
 	return nil
 }
@@ -388,28 +462,68 @@ func mergeMCPServer(mcpPath string) error {
 	return writeJSONFile(mcpPath, root)
 }
 
-// routingImportRef is the Claude Code import reference for the capy routing instructions file.
-const routingImportRef = "@.claude/capy/CLAUDE.md"
+// codexMCPMarker is the TOML table header that indicates capy is registered as an MCP server.
+const codexMCPMarker = "[mcp_servers.capy]"
+
+// codexMCPBlock is the TOML block appended to config.toml to register capy.
+const codexMCPBlock = `[mcp_servers.capy]
+command = "bash"
+args = ["` + codexWrapperRelPath + `", "serve"]
+`
+
+// mergeCodexMCPServer ensures .codex/config.toml has a [mcp_servers.capy] entry.
+// Uses string-based detection and append to preserve existing formatting and comments.
+func mergeCodexMCPServer(configPath string) error {
+	content, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	text := string(content)
+
+	if strings.Contains(text, codexMCPMarker) {
+		return nil
+	}
+
+	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if len(content) > 0 && !strings.HasSuffix(text, "\n") {
+		fmt.Fprint(f, "\n")
+	}
+	if len(content) > 0 && !strings.HasSuffix(text, "\n\n") {
+		fmt.Fprint(f, "\n")
+	}
+
+	_, err = fmt.Fprint(f, codexMCPBlock)
+	return err
+}
+
+// agentsRelPath is the platform-neutral path to generated routing instructions.
+const agentsRelPath = ".capy/AGENTS.md"
+
+// routingImportRef is the Claude Code import reference for the routing instructions file.
+const routingImportRef = "@.capy/AGENTS.md"
+
+// oldRoutingImportRef is the previous import path, used for migration.
+const oldRoutingImportRef = "@.claude/capy/CLAUDE.md"
 
 // routingImportBlock is the full block appended to root CLAUDE.md to import capy routing.
 const routingImportBlock = "# capy — MANDATORY routing rules\n\n" + routingImportRef + "\n"
 
-// writeRoutingInstructions writes routing instructions to .claude/capy/CLAUDE.md
-// and ensures root CLAUDE.md imports them. If root CLAUDE.md has the old inline
-// routing block, it is replaced with the import reference.
-func writeRoutingInstructions(claudeDir, claudeMDPath string) error {
-	// Step A: Write .claude/capy/CLAUDE.md (always overwrite — generated content)
-	capyDir := filepath.Join(claudeDir, "capy")
-	if err := os.MkdirAll(capyDir, 0o755); err != nil {
-		return fmt.Errorf("creating .claude/capy directory: %w", err)
-	}
+// writeAgentsFile writes routing instructions to .capy/AGENTS.md.
+func writeAgentsFile(projectDir string) error {
+	agentsPath := filepath.Join(projectDir, agentsRelPath)
+	return os.WriteFile(agentsPath, []byte(GenerateRoutingInstructions()), 0o644)
+}
 
-	capyCLAUDEMD := filepath.Join(capyDir, "CLAUDE.md")
-	if err := os.WriteFile(capyCLAUDEMD, []byte(GenerateRoutingInstructions()), 0o644); err != nil {
-		return fmt.Errorf("writing %s: %w", capyCLAUDEMD, err)
-	}
-
-	// Step B: Ensure root CLAUDE.md imports .claude/capy/CLAUDE.md
+// ensureClaudeMDImport ensures root CLAUDE.md imports the routing instructions
+// from .capy/AGENTS.md. Handles migration from inline routing blocks and from
+// the old .claude/capy/CLAUDE.md import path.
+func ensureClaudeMDImport(claudeMDPath string) error {
 	content, err := os.ReadFile(claudeMDPath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -417,9 +531,15 @@ func writeRoutingInstructions(claudeDir, claudeMDPath string) error {
 
 	text := string(content)
 
-	// Already has the import → nothing to do
+	// Already has the current import → nothing to do
 	if strings.Contains(text, routingImportRef) {
 		return nil
+	}
+
+	// Old import path (.claude/capy/CLAUDE.md) → replace with new path
+	if strings.Contains(text, oldRoutingImportRef) {
+		text = strings.ReplaceAll(text, oldRoutingImportRef, routingImportRef)
+		return os.WriteFile(claudeMDPath, []byte(text), 0o644)
 	}
 
 	// Old inline routing block present → replace with import.
@@ -429,10 +549,8 @@ func writeRoutingInstructions(claudeDir, claudeMDPath string) error {
 	if startIdx := strings.Index(text, startMarker); startIdx >= 0 {
 		rest := text[startIdx+len(startMarker):]
 		if endIdx := strings.Index(rest, "\n# "); endIdx >= 0 {
-			// Content follows after the capy block — preserve it
 			text = text[:startIdx] + routingImportBlock + rest[endIdx+1:]
 		} else {
-			// Capy block extends to EOF
 			text = text[:startIdx] + routingImportBlock
 		}
 		return os.WriteFile(claudeMDPath, []byte(text), 0o644)
@@ -445,7 +563,6 @@ func writeRoutingInstructions(claudeDir, claudeMDPath string) error {
 	}
 	defer f.Close()
 
-	// Add separator if file already has content
 	if len(content) > 0 && !strings.HasSuffix(text, "\n\n") {
 		if strings.HasSuffix(text, "\n") {
 			fmt.Fprint(f, "\n")
@@ -456,6 +573,13 @@ func writeRoutingInstructions(claudeDir, claudeMDPath string) error {
 
 	_, err = fmt.Fprint(f, routingImportBlock)
 	return err
+}
+
+// cleanupOldRoutingFile removes the old .claude/capy/CLAUDE.md if it exists.
+func cleanupOldRoutingFile(projectDir string) {
+	oldPath := filepath.Join(projectDir, ".claude", "capy", "CLAUDE.md")
+	os.Remove(oldPath)
+	os.Remove(filepath.Join(projectDir, ".claude", "capy"))
 }
 
 // ensureGitignoreEntry adds an entry to .gitignore if not already present.

--- a/internal/platform/setup_test.go
+++ b/internal/platform/setup_test.go
@@ -80,25 +80,26 @@ func TestSetupClaudeCode(t *testing.T) {
 	assert.Equal(t, "bash", capyServer["command"])
 	assert.Equal(t, []any{capyWrapperRelPath, "serve"}, capyServer["args"])
 
-	// Verify .claude/capy/CLAUDE.md has routing instructions
-	capyCLAUDEMD, err := os.ReadFile(filepath.Join(dir, ".claude", "capy", "CLAUDE.md"))
+	// Verify .capy/AGENTS.md has routing instructions
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Contains(t, string(capyCLAUDEMD), "capy_batch_execute")
-	assert.Contains(t, string(capyCLAUDEMD), "capy_search")
-	assert.Contains(t, string(capyCLAUDEMD), "capy_execute")
-	assert.Contains(t, string(capyCLAUDEMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
+	assert.Contains(t, string(agentsMD), "capy_search")
+	assert.Contains(t, string(agentsMD), "capy_execute")
+	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
 
 	// Verify root CLAUDE.md has import, not inline routing
 	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
 	require.NoError(t, err)
-	assert.Contains(t, string(claudeMD), "@.claude/capy/CLAUDE.md")
+	assert.Contains(t, string(claudeMD), "@.capy/AGENTS.md")
 	assert.NotContains(t, string(claudeMD), "capy_batch_execute",
 		"root CLAUDE.md should not contain inline routing instructions")
 
-	// Verify .gitignore has .capy/
+	// Verify .gitignore has .capy/** and AGENTS.md exception
 	gitignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
 	require.NoError(t, err)
-	assert.Contains(t, string(gitignore), ".capy/")
+	assert.Contains(t, string(gitignore), ".capy/**")
+	assert.Contains(t, string(gitignore), "!.capy/AGENTS.md")
 }
 
 func TestSetupIdempotent(t *testing.T) {
@@ -132,16 +133,16 @@ func TestSetupIdempotent(t *testing.T) {
 	// Root CLAUDE.md should not have duplicate imports
 	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(string(claudeMD), "@.claude/capy/CLAUDE.md"),
+	assert.Equal(t, 1, strings.Count(string(claudeMD), "@.capy/AGENTS.md"),
 		"should not duplicate routing import")
 	assert.NotContains(t, string(claudeMD), "capy_batch_execute",
 		"root CLAUDE.md should not contain inline routing instructions")
 
-	// .claude/capy/CLAUDE.md should have routing instructions
-	capyCLAUDEMD, err := os.ReadFile(filepath.Join(dir, ".claude", "capy", "CLAUDE.md"))
+	// .capy/AGENTS.md should have routing instructions
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(string(capyCLAUDEMD), "capy — MANDATORY routing rules"),
-		"should not duplicate routing instructions in capy CLAUDE.md")
+	assert.Equal(t, 1, strings.Count(string(agentsMD), "capy — MANDATORY routing rules"),
+		"should not duplicate routing instructions in AGENTS.md")
 
 	// .gitignore should not have duplicate entries
 	gitignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -280,14 +281,14 @@ func TestMergePreservesExistingCLAUDEMD(t *testing.T) {
 	content := string(claudeMD)
 	assert.Contains(t, content, "# My Project")
 	assert.Contains(t, content, "Some custom instructions.")
-	assert.Contains(t, content, "@.claude/capy/CLAUDE.md")
+	assert.Contains(t, content, "@.capy/AGENTS.md")
 	assert.NotContains(t, content, "capy_batch_execute",
 		"root CLAUDE.md should not contain inline routing instructions")
 
 	// Verify routing instructions written to separate file
-	capyCLAUDEMD, err := os.ReadFile(filepath.Join(dir, ".claude", "capy", "CLAUDE.md"))
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Contains(t, string(capyCLAUDEMD), "capy_batch_execute")
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
 }
 
 func TestSetupMigratesInlineRouting(t *testing.T) {
@@ -308,17 +309,17 @@ func TestSetupMigratesInlineRouting(t *testing.T) {
 	content := string(claudeMD)
 	assert.Contains(t, content, "# My Project")
 	assert.Contains(t, content, "Some custom instructions.")
-	assert.Contains(t, content, "@.claude/capy/CLAUDE.md")
+	assert.Contains(t, content, "@.capy/AGENTS.md")
 	assert.Contains(t, content, "# Extra Section")
 	assert.Contains(t, content, "More content after capy block.")
 	assert.NotContains(t, content, "capy_batch_execute",
 		"inline routing should be replaced with import")
 
 	// Routing instructions written to separate file
-	capyCLAUDEMD, err := os.ReadFile(filepath.Join(dir, ".claude", "capy", "CLAUDE.md"))
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Contains(t, string(capyCLAUDEMD), "capy_batch_execute")
-	assert.Contains(t, string(capyCLAUDEMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
+	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
 }
 
 func TestSetupMigratesStaleInlineRouting(t *testing.T) {
@@ -341,7 +342,7 @@ func TestSetupMigratesStaleInlineRouting(t *testing.T) {
 	content := string(claudeMD)
 
 	// Stale inline block replaced with import
-	assert.Contains(t, content, "@.claude/capy/CLAUDE.md")
+	assert.Contains(t, content, "@.capy/AGENTS.md")
 	assert.NotContains(t, content, "Old routing content from v0.1",
 		"stale inline routing should be removed")
 	assert.NotContains(t, content, "Stale instructions here",
@@ -354,9 +355,41 @@ func TestSetupMigratesStaleInlineRouting(t *testing.T) {
 	assert.Contains(t, content, "User content after capy block.")
 
 	// Current routing written to separate file
-	capyCLAUDEMD, err := os.ReadFile(filepath.Join(dir, ".claude", "capy", "CLAUDE.md"))
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Contains(t, string(capyCLAUDEMD), "capy_batch_execute")
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
+}
+
+func TestSetupMigratesOldImportPath(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	// Create CLAUDE.md with old import path (@.claude/capy/CLAUDE.md)
+	oldContent := "# My Project\n\n# capy — MANDATORY routing rules\n\n@.claude/capy/CLAUDE.md\n\n# Footer\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(oldContent), 0o644))
+
+	// Create old .claude/capy/CLAUDE.md (should be cleaned up)
+	oldCapyDir := filepath.Join(dir, ".claude", "capy")
+	require.NoError(t, os.MkdirAll(oldCapyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldCapyDir, "CLAUDE.md"), []byte("old"), 0o644))
+
+	require.NoError(t, SetupClaudeCode(binaryPath, dir, SettingsProject))
+
+	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	require.NoError(t, err)
+	content := string(claudeMD)
+	assert.Contains(t, content, "@.capy/AGENTS.md")
+	assert.NotContains(t, content, "@.claude/capy/CLAUDE.md")
+	assert.Contains(t, content, "# Footer")
+
+	// Old file should be cleaned up
+	_, err = os.Stat(filepath.Join(oldCapyDir, "CLAUDE.md"))
+	assert.True(t, os.IsNotExist(err), "old .claude/capy/CLAUDE.md should be removed")
+
+	// New file should exist
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
+	require.NoError(t, err)
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
 }
 
 func TestSetupMigratesInlineRouting_Idempotent(t *testing.T) {
@@ -374,9 +407,156 @@ func TestSetupMigratesInlineRouting_Idempotent(t *testing.T) {
 	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
 	require.NoError(t, err)
 	content := string(claudeMD)
-	assert.Equal(t, 1, strings.Count(content, "@.claude/capy/CLAUDE.md"),
+	assert.Equal(t, 1, strings.Count(content, "@.capy/AGENTS.md"),
 		"should have exactly one import after migration + re-run")
 	assert.Contains(t, content, "# Footer")
+}
+
+func TestSetupCodex(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	err := SetupCodex(binaryPath, dir)
+	require.NoError(t, err)
+
+	// Verify .capy/ directory created
+	info, err := os.Stat(filepath.Join(dir, ".capy"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Verify wrapper script created at .codex/scripts/capy.sh
+	wrapperPath := filepath.Join(dir, codexWrapperRelPath)
+	wrapperData, err := os.ReadFile(wrapperPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(wrapperData), "#!/usr/bin/env bash")
+	assert.Contains(t, string(wrapperData), "\"$p\" \"$@\" || true")
+
+	wrapperInfo, err := os.Stat(wrapperPath)
+	require.NoError(t, err)
+	assert.NotZero(t, wrapperInfo.Mode()&0o111, "wrapper script should be executable")
+
+	// Verify .capy/AGENTS.md has routing instructions
+	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
+	require.NoError(t, err)
+	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy_batch_execute")
+
+	// Verify .codex/config.toml has MCP server
+	configToml, err := os.ReadFile(filepath.Join(dir, ".codex", "config.toml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configToml), "[mcp_servers.capy]")
+	assert.Contains(t, string(configToml), codexWrapperRelPath)
+
+	// Verify .gitignore has .capy/** and AGENTS.md exception
+	gitignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	require.NoError(t, err)
+	assert.Contains(t, string(gitignore), ".capy/**")
+	assert.Contains(t, string(gitignore), "!.capy/AGENTS.md")
+}
+
+func TestSetupCodex_CreatesCodexDir(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	// .codex doesn't exist yet — setup should create it
+	err := SetupCodex(binaryPath, dir)
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, ".codex"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestSetupCodex_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	require.NoError(t, SetupCodex(binaryPath, dir))
+	require.NoError(t, SetupCodex(binaryPath, dir))
+
+	// Wrapper should still be valid
+	wrapperData, err := os.ReadFile(filepath.Join(dir, codexWrapperRelPath))
+	require.NoError(t, err)
+	assert.Contains(t, string(wrapperData), "#!/usr/bin/env bash")
+
+	// .gitignore should not have duplicate entries
+	gitignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	require.NoError(t, err)
+	lines := 0
+	for _, line := range splitLines(string(gitignore)) {
+		if line == ".capy/**" {
+			lines++
+		}
+	}
+	assert.Equal(t, 1, lines, "should not duplicate .gitignore entry")
+
+	// MCP config should not be duplicated
+	configToml, err := os.ReadFile(filepath.Join(dir, ".codex", "config.toml"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(configToml), "[mcp_servers.capy]"),
+		"should not duplicate MCP server entry")
+}
+
+func TestMergeCodexMCPServer_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	require.NoError(t, mergeCodexMCPServer(configPath))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "[mcp_servers.capy]")
+	assert.Contains(t, string(data), codexWrapperRelPath)
+}
+
+func TestMergeCodexMCPServer_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	existing := "#:schema https://developers.openai.com/codex/config-schema.json\nmodel = \"gpt-5.5\"\n\n[features]\ncodex_hooks = true\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	require.NoError(t, mergeCodexMCPServer(configPath))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "#:schema")
+	assert.Contains(t, content, `model = "gpt-5.5"`)
+	assert.Contains(t, content, "[features]")
+	assert.Contains(t, content, "[mcp_servers.capy]")
+}
+
+func TestMergeCodexMCPServer_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	existing := "model = \"gpt-5.5\"\n\n[mcp_servers.capy]\ncommand = \"bash\"\nargs = [\".codex/scripts/capy.sh\", \"serve\"]\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	require.NoError(t, mergeCodexMCPServer(configPath))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, existing, string(data), "should not modify file when MCP server already exists")
+}
+
+func TestSetupCodex_WrapperMatchesClaudeCode(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	// Setup both platforms
+	require.NoError(t, SetupCodex(binaryPath, dir))
+	require.NoError(t, SetupClaudeCode(binaryPath, dir, SettingsProject))
+
+	// Both wrapper scripts should have identical content
+	codexWrapper, err := os.ReadFile(filepath.Join(dir, codexWrapperRelPath))
+	require.NoError(t, err)
+	claudeWrapper, err := os.ReadFile(filepath.Join(dir, capyWrapperRelPath))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(claudeWrapper), string(codexWrapper),
+		"Codex and Claude Code wrapper scripts should be identical")
 }
 
 func TestWriteCapyWrapper(t *testing.T) {


### PR DESCRIPTION
Setup now targets both Claude Code and Codex by default, with --platform to narrow to one. Key changes:

- Move routing instructions from .claude/capy/CLAUDE.md to platform-neutral .capy/AGENTS.md (with gitignore exception and old-path migration)
- Add SetupCodex: creates wrapper script, merges MCP server into .codex/config.toml, writes AGENTS.md
- Extract writeWrapperScript helper shared by both platforms
- Split writeRoutingInstructions into writeAgentsFile (shared) + ensureClaudeMDImport (Claude Code only)
- String-based TOML merge for Codex MCP config (preserves formatting)

Closes #29 is tracked separately for Codex hooks support.