### PR TITLE
Forward CAPY_DB_KEY env var in codex MCP server config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,3 +19,4 @@ terminal_title = ["project", "git-branch", "status", "thread", "task-progress"]
 [mcp_servers.capy]
 command = "bash"
 args = [".codex/scripts/capy.sh", "serve"]
+env_vars = ["CAPY_DB_KEY"]

--- a/internal/platform/setup.go
+++ b/internal/platform/setup.go
@@ -479,13 +479,17 @@ func mergeMCPServer(mcpPath string) error {
 const codexMCPMarker = "[mcp_servers.capy]"
 
 // codexMCPBlock is the TOML block appended to config.toml to register capy.
+// env_vars forwards CAPY_DB_KEY from the local environment so the MCP server
+// can decrypt the knowledge database.
 const codexMCPBlock = `[mcp_servers.capy]
 command = "bash"
 args = ["` + codexWrapperRelPath + `", "serve"]
+env_vars = ["CAPY_DB_KEY"]
 `
 
-// mergeCodexMCPServer ensures .codex/config.toml has a [mcp_servers.capy] entry.
-// Uses string-based detection and append to preserve existing formatting and comments.
+// mergeCodexMCPServer ensures .codex/config.toml has an up-to-date [mcp_servers.capy] entry.
+// If the block exists but is stale (e.g. missing env_vars), it is replaced in-place.
+// Uses string-based detection to preserve existing formatting and comments.
 func mergeCodexMCPServer(configPath string) error {
 	content, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -495,7 +499,11 @@ func mergeCodexMCPServer(configPath string) error {
 	text := string(content)
 
 	if strings.Contains(text, codexMCPMarker) {
-		return nil
+		updated, changed := replaceCodexMCPBlock(text)
+		if !changed {
+			return nil
+		}
+		return os.WriteFile(configPath, []byte(updated), 0o644)
 	}
 
 	f, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
@@ -513,6 +521,36 @@ func mergeCodexMCPServer(configPath string) error {
 
 	_, err = fmt.Fprint(f, codexMCPBlock)
 	return err
+}
+
+// replaceCodexMCPBlock replaces the [mcp_servers.capy] TOML table in text with
+// codexMCPBlock if they differ. Returns the updated text and whether a change
+// was made. A TOML table runs from its header to the next table header or EOF.
+func replaceCodexMCPBlock(text string) (string, bool) {
+	markerIdx := strings.Index(text, codexMCPMarker)
+	if markerIdx < 0 {
+		return text, false
+	}
+
+	afterMarker := text[markerIdx+len(codexMCPMarker):]
+	blockEndRel := len(afterMarker)
+	if pos := strings.Index(afterMarker, "\n["); pos >= 0 {
+		blockEndRel = pos + 1
+	}
+	blockEnd := markerIdx + len(codexMCPMarker) + blockEndRel
+
+	existing := text[markerIdx:blockEnd]
+
+	if strings.TrimRight(existing, " \t\n\r") == strings.TrimRight(codexMCPBlock, " \t\n\r") {
+		return text, false
+	}
+
+	replacement := codexMCPBlock
+	if blockEnd < len(text) && !strings.HasSuffix(codexMCPBlock, "\n\n") {
+		replacement = strings.TrimRight(replacement, "\n") + "\n\n"
+	}
+
+	return text[:markerIdx] + replacement + text[blockEnd:], true
 }
 
 // agentsRelPath is the platform-neutral path to generated routing instructions.

--- a/internal/platform/setup_test.go
+++ b/internal/platform/setup_test.go
@@ -442,11 +442,12 @@ func TestSetupCodex(t *testing.T) {
 	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
 	assert.Contains(t, string(agentsMD), "capy_batch_execute")
 
-	// Verify .codex/config.toml has MCP server
+	// Verify .codex/config.toml has MCP server with env_vars
 	configToml, err := os.ReadFile(filepath.Join(dir, ".codex", "config.toml"))
 	require.NoError(t, err)
 	assert.Contains(t, string(configToml), "[mcp_servers.capy]")
 	assert.Contains(t, string(configToml), codexWrapperRelPath)
+	assert.Contains(t, string(configToml), `env_vars = ["CAPY_DB_KEY"]`)
 
 	// Verify .gitignore has .capy/** and AGENTS.md exception
 	gitignore, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -508,6 +509,7 @@ func TestMergeCodexMCPServer_NewFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "[mcp_servers.capy]")
 	assert.Contains(t, string(data), codexWrapperRelPath)
+	assert.Contains(t, string(data), `env_vars = ["CAPY_DB_KEY"]`)
 }
 
 func TestMergeCodexMCPServer_PreservesExisting(t *testing.T) {
@@ -532,7 +534,7 @@ func TestMergeCodexMCPServer_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 
-	existing := "model = \"gpt-5.5\"\n\n[mcp_servers.capy]\ncommand = \"bash\"\nargs = [\".codex/scripts/capy.sh\", \"serve\"]\n"
+	existing := "model = \"gpt-5.5\"\n\n[mcp_servers.capy]\ncommand = \"bash\"\nargs = [\".codex/scripts/capy.sh\", \"serve\"]\nenv_vars = [\"CAPY_DB_KEY\"]\n"
 	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
 
 	require.NoError(t, mergeCodexMCPServer(configPath))
@@ -540,6 +542,42 @@ func TestMergeCodexMCPServer_Idempotent(t *testing.T) {
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	assert.Equal(t, existing, string(data), "should not modify file when MCP server already exists")
+}
+
+func TestMergeCodexMCPServer_UpdatesStaleBlock(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	// Old block without env_vars
+	stale := "model = \"gpt-5.5\"\n\n[mcp_servers.capy]\ncommand = \"bash\"\nargs = [\".codex/scripts/capy.sh\", \"serve\"]\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(stale), 0o644))
+
+	require.NoError(t, mergeCodexMCPServer(configPath))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, `env_vars = ["CAPY_DB_KEY"]`, "should add env_vars to stale block")
+	assert.Contains(t, content, `model = "gpt-5.5"`, "should preserve existing config")
+	assert.Equal(t, 1, strings.Count(content, "[mcp_servers.capy]"), "should not duplicate section")
+}
+
+func TestMergeCodexMCPServer_UpdatesStaleBlock_PreservesFollowing(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	// Old block without env_vars, followed by another section
+	stale := "[mcp_servers.capy]\ncommand = \"bash\"\nargs = [\".codex/scripts/capy.sh\", \"serve\"]\n\n[mcp_servers.other]\ncommand = \"node\"\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(stale), 0o644))
+
+	require.NoError(t, mergeCodexMCPServer(configPath))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, `env_vars = ["CAPY_DB_KEY"]`)
+	assert.Contains(t, content, "[mcp_servers.other]", "should preserve following section")
+	assert.Contains(t, content, `command = "node"`, "should preserve following section content")
 }
 
 func TestSetupCodex_WrapperMatchesClaudeCode(t *testing.T) {


### PR DESCRIPTION
Codex does not inherit the shell environment for MCP servers, so
CAPY_DB_KEY must be explicitly forwarded via env_vars in config.toml.
Also makes mergeCodexMCPServer smart enough to detect and replace
stale blocks (e.g. missing env_vars) instead of silently skipping.

## Test Plan
make test