### PR TITLE
Prevent capy from indexing instruction files - skills, checklists, configs

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -28,7 +28,7 @@ For everything else, use:
 - `capy_batch_execute(commands, queries)` — run multiple commands + search in ONE call
 - `capy_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
 
-### Read vs capy_execute_file
+### Read vs capy_execute_file / capy_index
 
 **Default to `Read`.** It's cheap for normal-sized files, shows you actual content (not just patterns you knew to grep for), and is required if an Edit follows. Use `offset`/`limit` to scope large files.
 
@@ -41,8 +41,10 @@ For everything else, use:
 - `capy_execute_file` to grep section headings, then `Read` the file anyway to Edit it. The Read makes the capy call pure overhead.
 - `capy_execute_file` on a code file to "explore structure." Use Serena's `get_symbols_overview` / `find_symbol` — purpose-built and cheaper.
 - `capy_execute_file` on a small/medium file (<2k lines) "to save context." The savings don't exist; you're adding latency.
+- `capy_index` on instruction files (skill definitions, checklists, plugin configs, review profiles). These documents must be `Read` and internalized whole — BM25 returns ranked fragments, which destroys structural relationships between sections. A checklist item saying "check X, but only if Y" becomes meaningless when Y landed in a different search result.
+- `capy_index` on files outside the project directory (e.g. plugin caches under `~/.claude/`, tool configs, system paths). These are instructions or configuration the LLM needs to follow, not project data to query.
 
-**Rule of thumb:** capy saves context only when content would otherwise enter context. If you're going to `Read` it anyway (for Edit, for line citations, for follow-ups), capy adds nothing.
+**Rule of thumb:** capy saves context only when raw data would otherwise flood context and you don't need the full content. If the document is meant to be followed as instructions, applied as a checklist, or read for comprehension — use `Read`. Indexing turns a coherent document into a bag of fragments.
 
 ### Grep (large results)
 Grep results can flood context. Use `capy_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.

--- a/internal/hook/routing.go
+++ b/internal/hook/routing.go
@@ -22,7 +22,8 @@ func RoutingBlock() string {
 
   <forbidden_actions>
     - DO NOT use Bash for commands producing >20 lines of output.
-    - DO NOT use Read for analysis (use execute_file). Read IS correct for files you intend to Edit.
+    - For large files (10k+ lines), prefer execute_file when you only need derived answers (counts, patterns). Read IS correct for any file you need to understand, follow as instructions, or edit.
+    - DO NOT use capy_index on instruction files (skills, checklists, configs, plugin files). Read them directly — they must be internalized whole, not searched as fragments.
     - DO NOT use WebFetch (use capy_fetch_and_index instead).
     - Bash is ONLY for git/mkdir/rm/mv/navigation.
   </forbidden_actions>

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -46,7 +46,7 @@ For everything else, use:
 - ` + "`capy_batch_execute(commands, queries)`" + ` — run multiple commands + search in ONE call
 - ` + "`capy_execute(language: \"shell\", code: \"...\")`" + ` — run in sandbox, only stdout enters context
 
-### Read vs capy_execute_file
+### Read vs capy_execute_file / capy_index
 
 **Default to ` + "`Read`" + `.** It's cheap for normal-sized files, shows you actual content (not just patterns you knew to grep for), and is required if an Edit follows. Use ` + "`offset`" + `/` + "`limit`" + ` to scope large files.
 
@@ -59,8 +59,10 @@ For everything else, use:
 - ` + "`capy_execute_file`" + ` to grep section headings, then ` + "`Read`" + ` the file anyway to Edit it. The Read makes the capy call pure overhead.
 - ` + "`capy_execute_file`" + ` on a code file to "explore structure." Use Serena's ` + "`get_symbols_overview`" + ` / ` + "`find_symbol`" + ` — purpose-built and cheaper.
 - ` + "`capy_execute_file`" + ` on a small/medium file (<2k lines) "to save context." The savings don't exist; you're adding latency.
+- ` + "`capy_index`" + ` on instruction files (skill definitions, checklists, plugin configs, review profiles). These documents must be ` + "`Read`" + ` and internalized whole — BM25 returns ranked fragments, which destroys structural relationships between sections. A checklist item saying "check X, but only if Y" becomes meaningless when Y landed in a different search result.
+- ` + "`capy_index`" + ` on files outside the project directory (e.g. plugin caches under ` + "`~/.claude/`" + `, tool configs, system paths). These are instructions or configuration the LLM needs to follow, not project data to query.
 
-**Rule of thumb:** capy saves context only when content would otherwise enter context. If you're going to ` + "`Read`" + ` it anyway (for Edit, for line citations, for follow-ups), capy adds nothing.
+**Rule of thumb:** capy saves context only when raw data would otherwise flood context and you don't need the full content. If the document is meant to be followed as instructions, applied as a checklist, or read for comprehension — use ` + "`Read`" + `. Indexing turns a coherent document into a bag of fragments.
 
 ### Grep (large results)
 Grep results can flood context. Use ` + "`capy_execute(language: \"shell\", code: \"grep ...\")`" + ` to run searches in sandbox. Only your printed summary enters context.


### PR DESCRIPTION
The routing rules pushed LLMs toward capy_index for any large file, including plugin skill definitions and review checklists that need to be read and internalized whole. BM25 fragments destroy structural relationships between sections, making checklists unusable.

Ref: serpro69/claude-toolbox#103