### PR TITLE
Fix session parser discarding text from non-cumulative progressive snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ capy encrypt
 | `capy doctor`          | Run diagnostics on the installation                   |
 | `capy which`           | Print the knowledge base path for the current project |
 | `capy cleanup`         | Remove stale knowledge base entries                   |
+| `capy sweep`           | Index past sessions (dry-run by default, `--force` to index, `--reindex` to re-parse all) |
 | `capy checkpoint`      | Flush WAL into main DB file for safe git commits      |
 | `capy encrypt`         | Encrypt the knowledge DB or rotate its encryption key |
 | `capy hook <event>`    | Handle a hook event (called by Claude Code, not you)  |

--- a/cmd/capy/main.go
+++ b/cmd/capy/main.go
@@ -36,6 +36,7 @@ func main() {
 		newCheckpointCmd(),
 		newEncryptCmd(),
 		newWhichCmd(),
+		newSweepCmd(),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/serpro69/capy/internal/config"
+	"github.com/serpro69/capy/internal/session"
+	"github.com/serpro69/capy/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newSweepCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sweep",
+		Short: "Index past Claude Code sessions into the knowledge base",
+		Long:  "Parse and index session JSONL files. Runs in dry-run mode by default, showing what would be indexed. Use --force to actually index.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectDir, _ := cmd.Flags().GetString("project-dir")
+			if projectDir == "" {
+				projectDir = config.DetectProjectRoot()
+			}
+
+			cfg, _ := config.Load(projectDir)
+			if cfg == nil {
+				cfg = config.DefaultConfig()
+			}
+
+			force, _ := cmd.Flags().GetBool("force")
+			reindex, _ := cmd.Flags().GetBool("reindex")
+			opts := session.SweepOptions{Reindex: reindex}
+
+			dbPath := cfg.ResolveDBPath(projectDir)
+			st := store.NewContentStore(dbPath, projectDir, 0)
+			defer st.Close()
+
+			if force {
+				return runSweepForce(st, projectDir, opts)
+			}
+			return runSweepDryRun(st, projectDir, opts)
+		},
+	}
+	cmd.Flags().Bool("force", false, "actually index sessions (default is dry-run)")
+	cmd.Flags().Bool("reindex", false, "ignore mtime checks, re-parse all sessions")
+	return cmd
+}
+
+func runSweepDryRun(st *store.ContentStore, projectDir string, opts session.SweepOptions) error {
+	results, err := session.DryRunSweep(projectDir, st, opts)
+	if err != nil {
+		return fmt.Errorf("sweep failed: %w", err)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("capy sweep: no session files found")
+		return nil
+	}
+
+	fmt.Printf("%-38s %8s %5s %5s %8s  %s\n", "UUID", "SIZE", "PAIRS", "MAIN", "CHARS", "STATUS")
+	fmt.Println("-----------------------------------------------------------------------------------------------")
+
+	var indexable, alreadyIndexed, notIndexable, parseErrors int
+	for _, d := range results {
+		status := sweepStatus(d)
+		fmt.Printf("%-38s %8s %5d %5d %8d  %s\n",
+			d.UUID, formatSize(d.Size), d.TurnPairs, d.MainPairs, d.AssistantChars, status)
+
+		switch {
+		case d.ParseError != "":
+			parseErrors++
+		case d.AlreadyIndexed:
+			alreadyIndexed++
+		case d.Indexable:
+			indexable++
+		default:
+			notIndexable++
+		}
+	}
+
+	fmt.Printf("\nTotal: %d | Indexable: %d | Already indexed: %d | Not indexable: %d | Errors: %d\n",
+		len(results), indexable, alreadyIndexed, notIndexable, parseErrors)
+
+	if indexable > 0 {
+		fmt.Println("\nUse --force to index the indexable sessions.")
+	}
+
+	return nil
+}
+
+func runSweepForce(st *store.ContentStore, projectDir string, opts session.SweepOptions) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	indexed, skipped, errors := session.SweepWithOptions(ctx, st, projectDir, opts)
+	fmt.Printf("capy sweep: indexed %d, skipped %d, errors %d\n", indexed, skipped, errors)
+	if errors > 0 {
+		return fmt.Errorf("%d session(s) failed to index", errors)
+	}
+	return nil
+}
+
+func sweepStatus(d session.SessionDiagnostic) string {
+	if d.ParseError != "" {
+		return fmt.Sprintf("error: %s", d.ParseError)
+	}
+	if d.AlreadyIndexed {
+		return "already indexed"
+	}
+	if d.Indexable {
+		return "indexable"
+	}
+	if d.MainPairs < 2 {
+		return fmt.Sprintf("too few pairs (%d, need ≥2)", d.MainPairs)
+	}
+	return fmt.Sprintf("too few chars (%d, need ≥200)", d.AssistantChars)
+}
+
+func formatSize(bytes int64) string {
+	switch {
+	case bytes >= 1024*1024:
+		return fmt.Sprintf("%.1fMB", float64(bytes)/(1024*1024))
+	case bytes >= 1024:
+		return fmt.Sprintf("%.0fKB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}

--- a/docs/wip/sessionflow-rag/design.md
+++ b/docs/wip/sessionflow-rag/design.md
@@ -108,7 +108,7 @@ Claude Code JSONL files contain one JSON object per line. Each has a `type` fiel
 - `message.content` is always an array.
 - Block types: `text` (keep), `tool_use` (extract `name` field only), `thinking` (skip — content is empty string, only `signature` field has data).
 - Tool name path: `message.content[i].name` where `message.content[i].type == "tool_use"`.
-- Exactly 1 `tool_use` per assistant message (observed invariant).
+- **Progressive snapshots are non-cumulative:** Claude Code writes one content block per JSONL line, each sharing the same `message.id`. A typical assistant response produces 2-4 lines: `[thinking]`, `[text]`, `[tool_use]`, `[tool_use]`. The parser merges all blocks sharing the same `message.id` into a single logical message, deduplicating by (type, text, name) to also handle cumulative snapshot formats gracefully.
 
 ### Sub-Agent Conversations
 

--- a/docs/wip/sessionflow-rag/implementation.md
+++ b/docs/wip/sessionflow-rag/implementation.md
@@ -123,11 +123,12 @@ Create a session JSONL parser that reads a file and produces a filtered transcri
 2. Parses each line as JSON.
 3. Routes on `type` field:
    - `"user"`: extract text content (string or text blocks from array). Skip tool_result-only messages. Skip messages starting with `/`. Strip `<system-reminder>` tags.
-   - `"assistant"`: extract text from `text` blocks. Extract tool names from `tool_use` blocks. Skip `thinking` blocks.
+   - `"assistant"`: merge progressive snapshots (see below), then extract text from `text` blocks. Extract tool names from `tool_use` blocks. Skip `thinking` blocks.
    - `"system"` with `subtype == "away_summary"`: extract `content` field.
    - All other types: skip.
-4. Builds turn pairs: a turn pair is a human text message followed by assistant text response(s). Tool names from assistant tool_use blocks are collected per turn.
-5. Extracts session metadata: first user message timestamp (for the label datetime), session UUID (from `sessionId` field or filename).
+4. **Progressive snapshot merging:** Claude Code writes one content block per JSONL line, all sharing the same `message.id` (non-cumulative format). A single assistant response typically produces 2-4 lines: `[thinking]`, `[text]`, `[tool_use]`, etc. The parser collects all blocks across lines sharing the same `message.id` into a single logical message, deduplicating by `(type, text, name, id)` to also handle cumulative snapshot formats. This happens in the first pass before text extraction.
+5. Builds turn pairs: a turn pair is a human text message followed by assistant text response(s). Tool names from assistant tool_use blocks are collected per turn.
+6. Extracts session metadata: first user message timestamp (for the label datetime), session UUID (from `sessionId` field or filename).
 
 **Output type:**
 

--- a/internal/session/parse.go
+++ b/internal/session/parse.go
@@ -70,6 +70,7 @@ type contentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
 	Name string `json:"name"`
+	ID   string `json:"id"`
 }
 
 // parsedMessage is an intermediate representation after JSONL deduplication.
@@ -92,14 +93,15 @@ func ParseSession(path string) (*ParsedSession, error) {
 
 	sessionID := strings.TrimSuffix(filepath.Base(path), ".jsonl")
 
-	// First pass: parse all lines and deduplicate assistant progressive snapshots
-	// by message.id (keep last occurrence which has the most complete content).
+	// First pass: parse all lines and merge assistant progressive snapshots
+	// by message.id. Claude Code writes one content block per JSONL line
+	// (non-cumulative), so we collect all blocks sharing the same message.id.
 	type rawEntry struct {
-		order   int
-		line    jsonlLine
-		msgID   string // message.id for assistant dedup; uuid for others
-		rawMsg  jsonlMessage
-		hasMsgP bool // whether Message field was present and parsed
+		line         jsonlLine
+		msgID        string // message.id for assistant merge; uuid for others
+		rawMsg       jsonlMessage
+		hasMsgP      bool           // whether Message field was present and parsed
+		mergedBlocks []contentBlock // accumulated blocks from all progressive snapshots
 	}
 
 	var entries []rawEntry
@@ -121,7 +123,7 @@ func ParseSession(path string) (*ParsedSession, error) {
 			continue
 		}
 
-		entry := rawEntry{order: lineNum, line: line}
+		entry := rawEntry{line: line}
 
 		if len(line.Message) > 0 && string(line.Message) != "null" {
 			var msg jsonlMessage
@@ -145,13 +147,34 @@ func ParseSession(path string) (*ParsedSession, error) {
 				msgID = line.UUID
 			}
 			entry.msgID = msgID
-			if prevIdx, exists := assistantLastIdx[msgID]; exists {
-				entries[prevIdx].order = -1 // mark superseded
-				entries[prevIdx].line.Message = nil
-				entries[prevIdx].rawMsg.Content = nil
+
+			var blocks []contentBlock
+			if entry.hasMsgP && len(entry.rawMsg.Content) > 0 {
+				if err := json.Unmarshal(entry.rawMsg.Content, &blocks); err != nil {
+					slog.Warn("skipping malformed assistant content", "file", path, "line", lineNum, "error", err)
+				}
 			}
-			assistantLastIdx[msgID] = len(entries)
-			entries = append(entries, entry)
+
+			if prevIdx, exists := assistantLastIdx[msgID]; exists {
+				target := &entries[prevIdx]
+				for _, nb := range blocks {
+					dup := false
+					for _, eb := range target.mergedBlocks {
+						if eb.Type == nb.Type && eb.Text == nb.Text && eb.Name == nb.Name && eb.ID == nb.ID {
+							dup = true
+							break
+						}
+					}
+					if !dup {
+						target.mergedBlocks = append(target.mergedBlocks, nb)
+					}
+				}
+			} else {
+				entry.mergedBlocks = blocks
+				entry.rawMsg.Content = nil
+				assistantLastIdx[msgID] = len(entries)
+				entries = append(entries, entry)
+			}
 		case "system":
 			if line.Subtype == "away_summary" {
 				entry.msgID = line.UUID
@@ -169,10 +192,6 @@ func ParseSession(path string) (*ParsedSession, error) {
 	foundSessionID := sessionID
 
 	for _, entry := range entries {
-		if entry.order < 0 {
-			continue // superseded progressive snapshot
-		}
-
 		ts, _ := time.Parse(time.RFC3339Nano, entry.line.Timestamp)
 		if entry.line.SessionID != "" {
 			foundSessionID = entry.line.SessionID
@@ -198,10 +217,10 @@ func ParseSession(path string) (*ParsedSession, error) {
 			})
 
 		case "assistant":
-			if !entry.hasMsgP {
+			if len(entry.mergedBlocks) == 0 {
 				continue
 			}
-			text, toolNames := extractAssistantContent(entry.rawMsg.Content)
+			text, toolNames := extractAssistantBlocks(entry.mergedBlocks)
 			if text == "" && len(toolNames) == 0 {
 				continue
 			}
@@ -282,17 +301,8 @@ func cleanUserText(text string) string {
 	return text
 }
 
-// extractAssistantContent extracts text and tool names from assistant content blocks.
-func extractAssistantContent(raw json.RawMessage) (string, []string) {
-	if len(raw) == 0 {
-		return "", nil
-	}
-
-	var blocks []contentBlock
-	if err := json.Unmarshal(raw, &blocks); err != nil {
-		return "", nil
-	}
-
+// extractAssistantBlocks extracts text and tool names from pre-parsed content blocks.
+func extractAssistantBlocks(blocks []contentBlock) (string, []string) {
 	var texts []string
 	var toolNames []string
 	for _, b := range blocks {
@@ -307,9 +317,7 @@ func extractAssistantContent(raw json.RawMessage) (string, []string) {
 				toolNames = append(toolNames, b.Name)
 			}
 		}
-		// thinking blocks: skip (content is empty/signature only)
 	}
-
 	return strings.Join(texts, "\n"), toolNames
 }
 

--- a/internal/session/parse_test.go
+++ b/internal/session/parse_test.go
@@ -515,6 +515,301 @@ func TestParseSession_ProgressiveSnapshots(t *testing.T) {
 	}
 }
 
+func TestParseSession_NonCumulativeSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	// Real Claude Code format: each content block is a separate JSONL line
+	// with the same message.id but only 1 block per line (non-cumulative).
+	path := writeJSONL(t, dir, "noncum.jsonl", []jsonlEntry{
+		{
+			"type":      "user",
+			"uuid":      "u1",
+			"timestamp": "2026-04-05T12:00:00Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Read the config file and fix the settings",
+			},
+		},
+		// Block 1: thinking (separate line)
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap1",
+			"timestamp": "2026-04-05T12:00:01Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "thinking", "thinking": "", "signature": "sig1"},
+				},
+			},
+		},
+		// Block 2: text (separate line, same message.id)
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap2",
+			"timestamp": "2026-04-05T12:00:02Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "text", "text": "Let me read the config file first."},
+				},
+			},
+		},
+		// Block 3: tool_use (separate line, same message.id)
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap3",
+			"timestamp": "2026-04-05T12:00:03Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "tool_use", "id": "toolu_001", "name": "Read", "input": map[string]any{"path": "/config.toml"}},
+				},
+			},
+		},
+		// Tool result
+		{
+			"type":      "user",
+			"uuid":      "u2",
+			"timestamp": "2026-04-05T12:00:04Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": "toolu_001", "content": []map[string]any{
+						{"type": "text", "text": "timeout = 30"},
+					}},
+				},
+			},
+		},
+		// Second assistant message, also non-cumulative
+		{
+			"type":      "assistant",
+			"uuid":      "a2-snap1",
+			"timestamp": "2026-04-05T12:00:05Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_002",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "thinking", "thinking": "", "signature": "sig2"},
+				},
+			},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      "a2-snap2",
+			"timestamp": "2026-04-05T12:00:06Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_002",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "text", "text": "The timeout is set too low. Let me fix it."},
+				},
+			},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      "a2-snap3",
+			"timestamp": "2026-04-05T12:00:07Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_002",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "tool_use", "id": "toolu_002", "name": "Edit", "input": map[string]any{"path": "/config.toml"}},
+				},
+			},
+		},
+		// Second tool result
+		{
+			"type":      "user",
+			"uuid":      "u3",
+			"timestamp": "2026-04-05T12:00:08Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": "toolu_002", "content": []map[string]any{
+						{"type": "text", "text": "ok"},
+					}},
+				},
+			},
+		},
+		// Final human message
+		{
+			"type":      "user",
+			"uuid":      "u4",
+			"timestamp": "2026-04-05T12:01:00Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Perfect, that fixed it",
+			},
+		},
+		// Final assistant — single text block
+		{
+			"type":      "assistant",
+			"uuid":      "a3",
+			"timestamp": "2026-04-05T12:01:05Z",
+			"sessionId": "noncum-session",
+			"message": map[string]any{
+				"id":   "msg_003",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "text", "text": "The config is updated and working now."},
+				},
+			},
+		},
+	})
+
+	session, err := ParseSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two turn pairs: "Read the config..." → merged assistant with text + tools,
+	// then "Perfect..." → final assistant text.
+	// Tool-result-only user messages (u2, u3) are filtered out by extractUserText
+	// and don't create turn pair boundaries, so both msg_001 and msg_002 accumulate
+	// into the first turn pair.
+	if len(session.TurnPairs) != 2 {
+		t.Fatalf("got %d turn pairs, want 2", len(session.TurnPairs))
+	}
+
+	tp0 := session.TurnPairs[0]
+	if !strings.Contains(tp0.AssistantText, "Let me read the config file first.") {
+		t.Errorf("turn 0: missing text from first assistant block, got %q", tp0.AssistantText)
+	}
+	if !strings.Contains(tp0.AssistantText, "The timeout is set too low.") {
+		t.Errorf("turn 0: missing text from second assistant block, got %q", tp0.AssistantText)
+	}
+	if len(tp0.ToolNames) < 2 {
+		t.Fatalf("turn 0: want >= 2 tool names, got %v", tp0.ToolNames)
+	}
+	if tp0.ToolNames[0] != "Read" || tp0.ToolNames[1] != "Edit" {
+		t.Errorf("turn 0: ToolNames = %v, want [Read, Edit]", tp0.ToolNames)
+	}
+
+	tp1 := session.TurnPairs[1]
+	if tp1.AssistantText != "The config is updated and working now." {
+		t.Errorf("turn 1: AssistantText = %q", tp1.AssistantText)
+	}
+
+	if session.TotalAssistantChars <= 0 {
+		t.Errorf("TotalAssistantChars = %d, want > 0", session.TotalAssistantChars)
+	}
+}
+
+func TestParseSession_CumulativeSnapshotsDedup(t *testing.T) {
+	dir := t.TempDir()
+	// Cumulative format: each snapshot repeats previous blocks and adds new ones.
+	// Verify dedup prevents duplicate text in the merged result.
+	path := writeJSONL(t, dir, "cumdedup.jsonl", []jsonlEntry{
+		{
+			"type":      "user",
+			"uuid":      "u1",
+			"timestamp": "2026-04-05T12:00:00Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Explain the architecture",
+			},
+		},
+		// Snapshot 1: thinking only
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap1",
+			"timestamp": "2026-04-05T12:00:01Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "thinking", "thinking": "", "signature": "sig1"},
+				},
+			},
+		},
+		// Snapshot 2: thinking + text (cumulative)
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap2",
+			"timestamp": "2026-04-05T12:00:02Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "thinking", "thinking": "", "signature": "sig1"},
+					{"type": "text", "text": "The system uses clean architecture."},
+				},
+			},
+		},
+		// Snapshot 3: thinking + text + tool_use (cumulative)
+		{
+			"type":      "assistant",
+			"uuid":      "a1-snap3",
+			"timestamp": "2026-04-05T12:00:03Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "thinking", "thinking": "", "signature": "sig1"},
+					{"type": "text", "text": "The system uses clean architecture."},
+					{"type": "tool_use", "id": "toolu_001", "name": "Read", "input": map[string]any{"path": "/arch.md"}},
+				},
+			},
+		},
+		{
+			"type":      "user",
+			"uuid":      "u2",
+			"timestamp": "2026-04-05T12:01:00Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"role":    "user",
+				"content": "Thanks for the explanation",
+			},
+		},
+		{
+			"type":      "assistant",
+			"uuid":      "a2",
+			"timestamp": "2026-04-05T12:01:05Z",
+			"sessionId": "cumdedup-session",
+			"message": map[string]any{
+				"id":   "msg_002",
+				"role": "assistant",
+				"content": []map[string]any{
+					{"type": "text", "text": "Happy to help!"},
+				},
+			},
+		},
+	})
+
+	session, err := ParseSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(session.TurnPairs) != 2 {
+		t.Fatalf("got %d turn pairs, want 2", len(session.TurnPairs))
+	}
+
+	tp := session.TurnPairs[0]
+	if tp.AssistantText != "The system uses clean architecture." {
+		t.Errorf("expected single text (no duplicates from cumulative dedup), got %q", tp.AssistantText)
+	}
+	if len(tp.ToolNames) != 1 || tp.ToolNames[0] != "Read" {
+		t.Errorf("ToolNames = %v, want [Read]", tp.ToolNames)
+	}
+}
+
 func TestParseSession_SlashCommands(t *testing.T) {
 	dir := t.TempDir()
 	path := writeJSONL(t, dir, "slash.jsonl", []jsonlEntry{

--- a/internal/session/sweep.go
+++ b/internal/session/sweep.go
@@ -45,11 +45,99 @@ func manglePath(absPath string) string {
 	return strings.NewReplacer("/", "-", ".", "-").Replace(absPath)
 }
 
+// SweepOptions controls sweep behavior.
+type SweepOptions struct {
+	Reindex bool // ignore mtime checks, force re-parse of all sessions
+}
+
+// SessionDiagnostic holds per-session parse results for dry-run reporting.
+type SessionDiagnostic struct {
+	UUID           string
+	Size           int64
+	TurnPairs      int
+	MainPairs      int
+	AssistantChars int
+	Indexable      bool
+	AlreadyIndexed bool
+	ParseError     string
+}
+
+// DryRunSweep parses all sessions without indexing and returns per-session diagnostics.
+// Pass a non-nil ContentStore to check already-indexed status; pass nil to skip that check.
+func DryRunSweep(projectDir string, cs *store.ContentStore, opts SweepOptions) ([]SessionDiagnostic, error) {
+	dir, err := SessionDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("session directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("listing directory: %w", err)
+	}
+
+	var indexedMap map[string]time.Time
+	if !opts.Reindex && cs != nil {
+		indexedMap, _ = buildIndexedAtMap(cs)
+	}
+
+	var results []SessionDiagnostic
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		uuid := strings.TrimSuffix(e.Name(), ".jsonl")
+		info, _ := e.Info()
+
+		d := SessionDiagnostic{UUID: uuid}
+		if info != nil {
+			d.Size = info.Size()
+		}
+
+		if !opts.Reindex && indexedMap != nil {
+			if _, exists := indexedMap[uuid]; exists {
+				d.AlreadyIndexed = true
+			}
+		}
+
+		parsed, err := ParseSession(filepath.Join(dir, e.Name()))
+		if err != nil {
+			d.ParseError = err.Error()
+			results = append(results, d)
+			continue
+		}
+
+		subPairs, _ := ParseSubagents(filepath.Join(dir, uuid))
+		if len(subPairs) > 0 {
+			parsed.TurnPairs = append(parsed.TurnPairs, subPairs...)
+			for _, sp := range subPairs {
+				parsed.TotalAssistantChars += len(sp.AssistantText)
+			}
+		}
+
+		d.TurnPairs = len(parsed.TurnPairs)
+		for _, tp := range parsed.TurnPairs {
+			if !tp.IsSubagent {
+				d.MainPairs++
+			}
+		}
+		d.AssistantChars = parsed.TotalAssistantChars
+		d.Indexable = parsed.IsIndexable()
+		results = append(results, d)
+	}
+
+	return results, nil
+}
+
 // Sweep discovers, parses, and indexes Claude Code session files for the given
 // project. It checks ctx.Err() between files for cooperative cancellation.
 //
 // Returns counts of indexed, skipped, and errored sessions.
 func Sweep(ctx context.Context, cs *store.ContentStore, projectDir string) (indexed, skipped, errors int) {
+	return SweepWithOptions(ctx, cs, projectDir, SweepOptions{})
+}
+
+// SweepWithOptions is like Sweep but accepts options to control behavior.
+func SweepWithOptions(ctx context.Context, cs *store.ContentStore, projectDir string, opts SweepOptions) (indexed, skipped, errors int) {
 	dir, err := SessionDir(projectDir)
 	if err != nil {
 		slog.Debug("session sweep: directory not found, skipping", "project", projectDir, "error", err)
@@ -87,7 +175,7 @@ func Sweep(ctx context.Context, cs *store.ContentStore, projectDir string) (inde
 
 		uuid := strings.TrimSuffix(entry.Name(), ".jsonl")
 
-		if shouldSkip(dir, uuid, entry, indexedMap) {
+		if !opts.Reindex && shouldSkip(dir, uuid, entry, indexedMap) {
 			skipped++
 			continue
 		}

--- a/internal/session/sweep_test.go
+++ b/internal/session/sweep_test.go
@@ -602,3 +602,165 @@ func TestSweep_SecretSanitization_MultiWindow(t *testing.T) {
 		}
 	}
 }
+
+func TestDryRunSweep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-aaa")
+	writeTestSession(t, sessionDir, "sess-bbb")
+	if err := os.WriteFile(filepath.Join(sessionDir, "sess-tiny.jsonl"), []byte(`{"type":"user","message":{"role":"user","content":"x"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := DryRunSweep(projectDir, nil, SweepOptions{})
+	if err != nil {
+		t.Fatalf("DryRunSweep failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+
+	indexableCount := 0
+	for _, d := range results {
+		if d.Indexable {
+			indexableCount++
+			if d.MainPairs < 2 {
+				t.Errorf("session %s: indexable but mainPairs=%d", d.UUID, d.MainPairs)
+			}
+			if d.AssistantChars < 200 {
+				t.Errorf("session %s: indexable but chars=%d", d.UUID, d.AssistantChars)
+			}
+		}
+		if d.Size <= 0 {
+			t.Errorf("session %s: size=%d, want > 0", d.UUID, d.Size)
+		}
+	}
+	if indexableCount != 2 {
+		t.Errorf("got %d indexable sessions, want 2", indexableCount)
+	}
+}
+
+func TestDryRunSweep_AlreadyIndexed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-indexed")
+
+	dbPath := filepath.Join(projectDir, ".capy", "test.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-dryrun-indexed-32byt")
+
+	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	defer cs.Close()
+
+	ctx := context.Background()
+	_, err := indexSession(ctx, cs, sessionDir, "sess-indexed")
+	if err != nil {
+		t.Fatalf("indexSession failed: %v", err)
+	}
+
+	results, err := DryRunSweep(projectDir, cs, SweepOptions{})
+	if err != nil {
+		t.Fatalf("DryRunSweep failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if !results[0].AlreadyIndexed {
+		t.Error("expected session to be marked as already indexed")
+	}
+
+	// With Reindex, should NOT be marked as already indexed.
+	results2, err := DryRunSweep(projectDir, cs, SweepOptions{Reindex: true})
+	if err != nil {
+		t.Fatalf("DryRunSweep(reindex) failed: %v", err)
+	}
+	if results2[0].AlreadyIndexed {
+		t.Error("with Reindex=true, session should not be marked as already indexed")
+	}
+}
+
+func TestSweepWithOptions_Reindex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-reindex")
+
+	dbPath := filepath.Join(projectDir, ".capy", "test.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-reindex-sweep-32byte")
+
+	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	defer cs.Close()
+
+	ctx := context.Background()
+
+	// First sweep indexes the session.
+	indexed, _, errs := SweepWithOptions(ctx, cs, projectDir, SweepOptions{})
+	if indexed != 1 {
+		t.Fatalf("first sweep: indexed=%d, want 1", indexed)
+	}
+	if errs != 0 {
+		t.Fatalf("first sweep: errors=%d, want 0", errs)
+	}
+
+	// Reindex sweep re-processes even though the content hasn't changed.
+	// With content_hash dedup, the store updates access time but no error occurs.
+	indexed2, _, errs2 := SweepWithOptions(ctx, cs, projectDir, SweepOptions{Reindex: true})
+	if indexed2 != 1 {
+		t.Fatalf("reindex sweep: indexed=%d, want 1 (re-processed)", indexed2)
+	}
+	if errs2 != 0 {
+		t.Fatalf("reindex sweep: errors=%d, want 0", errs2)
+	}
+}


### PR DESCRIPTION
Claude Code writes each assistant content block as a separate JSONL line
sharing the same message.id (non-cumulative format). The parser's dedup
kept only the last line per message.id, which was typically a tool_use
block, silently discarding earlier text blocks. This caused 52% of
sessions to fail the indexability gate.

Replace keep-last dedup with block merging: collect all content blocks
across lines sharing the same message.id, deduplicating by (type, text,
name, id) to handle both cumulative and non-cumulative formats. Also
removes dead order-tracking code, adds unmarshal error logging, and
frees raw content bytes after extraction.

## Test Plan
make test