### PR TITLE
Add `capy sweep` CLI command for on-demand session indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ capy encrypt
 | `capy doctor`          | Run diagnostics on the installation                   |
 | `capy which`           | Print the knowledge base path for the current project |
 | `capy cleanup`         | Remove stale knowledge base entries                   |
+| `capy sweep`           | Index past sessions (dry-run by default, `--force` to index, `--reindex` to re-parse all) |
 | `capy checkpoint`      | Flush WAL into main DB file for safe git commits      |
 | `capy encrypt`         | Encrypt the knowledge DB or rotate its encryption key |
 | `capy hook <event>`    | Handle a hook event (called by Claude Code, not you)  |

--- a/cmd/capy/main.go
+++ b/cmd/capy/main.go
@@ -36,6 +36,7 @@ func main() {
 		newCheckpointCmd(),
 		newEncryptCmd(),
 		newWhichCmd(),
+		newSweepCmd(),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/serpro69/capy/internal/config"
+	"github.com/serpro69/capy/internal/session"
+	"github.com/serpro69/capy/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newSweepCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sweep",
+		Short: "Index past Claude Code sessions into the knowledge base",
+		Long:  "Parse and index session JSONL files. Runs in dry-run mode by default, showing what would be indexed. Use --force to actually index.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectDir, _ := cmd.Flags().GetString("project-dir")
+			if projectDir == "" {
+				projectDir = config.DetectProjectRoot()
+			}
+
+			cfg, _ := config.Load(projectDir)
+			if cfg == nil {
+				cfg = config.DefaultConfig()
+			}
+
+			force, _ := cmd.Flags().GetBool("force")
+			reindex, _ := cmd.Flags().GetBool("reindex")
+			opts := session.SweepOptions{Reindex: reindex}
+
+			dbPath := cfg.ResolveDBPath(projectDir)
+			st := store.NewContentStore(dbPath, projectDir, 0)
+			defer st.Close()
+
+			if force {
+				return runSweepForce(st, projectDir, opts)
+			}
+			return runSweepDryRun(st, projectDir, opts)
+		},
+	}
+	cmd.Flags().Bool("force", false, "actually index sessions (default is dry-run)")
+	cmd.Flags().Bool("reindex", false, "ignore mtime checks, re-parse all sessions")
+	return cmd
+}
+
+func runSweepDryRun(st *store.ContentStore, projectDir string, opts session.SweepOptions) error {
+	results, err := session.DryRunSweep(projectDir, st, opts)
+	if err != nil {
+		return fmt.Errorf("sweep failed: %w", err)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("capy sweep: no session files found")
+		return nil
+	}
+
+	fmt.Printf("%-38s %8s %5s %5s %8s  %s\n", "UUID", "SIZE", "PAIRS", "MAIN", "CHARS", "STATUS")
+	fmt.Println("-----------------------------------------------------------------------------------------------")
+
+	var indexable, alreadyIndexed, notIndexable, parseErrors int
+	for _, d := range results {
+		status := sweepStatus(d)
+		fmt.Printf("%-38s %8s %5d %5d %8d  %s\n",
+			d.UUID, formatSize(d.Size), d.TurnPairs, d.MainPairs, d.AssistantChars, status)
+
+		switch {
+		case d.ParseError != "":
+			parseErrors++
+		case d.AlreadyIndexed:
+			alreadyIndexed++
+		case d.Indexable:
+			indexable++
+		default:
+			notIndexable++
+		}
+	}
+
+	fmt.Printf("\nTotal: %d | Indexable: %d | Already indexed: %d | Not indexable: %d | Errors: %d\n",
+		len(results), indexable, alreadyIndexed, notIndexable, parseErrors)
+
+	if indexable > 0 {
+		fmt.Println("\nUse --force to index the indexable sessions.")
+	}
+
+	return nil
+}
+
+func runSweepForce(st *store.ContentStore, projectDir string, opts session.SweepOptions) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	indexed, skipped, errors := session.SweepWithOptions(ctx, st, projectDir, opts)
+	fmt.Printf("capy sweep: indexed %d, skipped %d, errors %d\n", indexed, skipped, errors)
+	if errors > 0 {
+		return fmt.Errorf("%d session(s) failed to index", errors)
+	}
+	return nil
+}
+
+func sweepStatus(d session.SessionDiagnostic) string {
+	if d.ParseError != "" {
+		return fmt.Sprintf("error: %s", d.ParseError)
+	}
+	if d.AlreadyIndexed {
+		return "already indexed"
+	}
+	if d.Indexable {
+		return "indexable"
+	}
+	if d.MainPairs < 2 {
+		return fmt.Sprintf("too few pairs (%d, need ≥2)", d.MainPairs)
+	}
+	return fmt.Sprintf("too few chars (%d, need ≥200)", d.AssistantChars)
+}
+
+func formatSize(bytes int64) string {
+	switch {
+	case bytes >= 1024*1024:
+		return fmt.Sprintf("%.1fMB", float64(bytes)/(1024*1024))
+	case bytes >= 1024:
+		return fmt.Sprintf("%.0fKB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}

--- a/internal/session/sweep.go
+++ b/internal/session/sweep.go
@@ -45,11 +45,99 @@ func manglePath(absPath string) string {
 	return strings.NewReplacer("/", "-", ".", "-").Replace(absPath)
 }
 
+// SweepOptions controls sweep behavior.
+type SweepOptions struct {
+	Reindex bool // ignore mtime checks, force re-parse of all sessions
+}
+
+// SessionDiagnostic holds per-session parse results for dry-run reporting.
+type SessionDiagnostic struct {
+	UUID           string
+	Size           int64
+	TurnPairs      int
+	MainPairs      int
+	AssistantChars int
+	Indexable      bool
+	AlreadyIndexed bool
+	ParseError     string
+}
+
+// DryRunSweep parses all sessions without indexing and returns per-session diagnostics.
+// Pass a non-nil ContentStore to check already-indexed status; pass nil to skip that check.
+func DryRunSweep(projectDir string, cs *store.ContentStore, opts SweepOptions) ([]SessionDiagnostic, error) {
+	dir, err := SessionDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("session directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("listing directory: %w", err)
+	}
+
+	var indexedMap map[string]time.Time
+	if !opts.Reindex && cs != nil {
+		indexedMap, _ = buildIndexedAtMap(cs)
+	}
+
+	var results []SessionDiagnostic
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		uuid := strings.TrimSuffix(e.Name(), ".jsonl")
+		info, _ := e.Info()
+
+		d := SessionDiagnostic{UUID: uuid}
+		if info != nil {
+			d.Size = info.Size()
+		}
+
+		if !opts.Reindex && indexedMap != nil {
+			if _, exists := indexedMap[uuid]; exists {
+				d.AlreadyIndexed = true
+			}
+		}
+
+		parsed, err := ParseSession(filepath.Join(dir, e.Name()))
+		if err != nil {
+			d.ParseError = err.Error()
+			results = append(results, d)
+			continue
+		}
+
+		subPairs, _ := ParseSubagents(filepath.Join(dir, uuid))
+		if len(subPairs) > 0 {
+			parsed.TurnPairs = append(parsed.TurnPairs, subPairs...)
+			for _, sp := range subPairs {
+				parsed.TotalAssistantChars += len(sp.AssistantText)
+			}
+		}
+
+		d.TurnPairs = len(parsed.TurnPairs)
+		for _, tp := range parsed.TurnPairs {
+			if !tp.IsSubagent {
+				d.MainPairs++
+			}
+		}
+		d.AssistantChars = parsed.TotalAssistantChars
+		d.Indexable = parsed.IsIndexable()
+		results = append(results, d)
+	}
+
+	return results, nil
+}
+
 // Sweep discovers, parses, and indexes Claude Code session files for the given
 // project. It checks ctx.Err() between files for cooperative cancellation.
 //
 // Returns counts of indexed, skipped, and errored sessions.
 func Sweep(ctx context.Context, cs *store.ContentStore, projectDir string) (indexed, skipped, errors int) {
+	return SweepWithOptions(ctx, cs, projectDir, SweepOptions{})
+}
+
+// SweepWithOptions is like Sweep but accepts options to control behavior.
+func SweepWithOptions(ctx context.Context, cs *store.ContentStore, projectDir string, opts SweepOptions) (indexed, skipped, errors int) {
 	dir, err := SessionDir(projectDir)
 	if err != nil {
 		slog.Debug("session sweep: directory not found, skipping", "project", projectDir, "error", err)
@@ -87,7 +175,7 @@ func Sweep(ctx context.Context, cs *store.ContentStore, projectDir string) (inde
 
 		uuid := strings.TrimSuffix(entry.Name(), ".jsonl")
 
-		if shouldSkip(dir, uuid, entry, indexedMap) {
+		if !opts.Reindex && shouldSkip(dir, uuid, entry, indexedMap) {
 			skipped++
 			continue
 		}

--- a/internal/session/sweep_test.go
+++ b/internal/session/sweep_test.go
@@ -602,3 +602,165 @@ func TestSweep_SecretSanitization_MultiWindow(t *testing.T) {
 		}
 	}
 }
+
+func TestDryRunSweep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-aaa")
+	writeTestSession(t, sessionDir, "sess-bbb")
+	if err := os.WriteFile(filepath.Join(sessionDir, "sess-tiny.jsonl"), []byte(`{"type":"user","message":{"role":"user","content":"x"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := DryRunSweep(projectDir, nil, SweepOptions{})
+	if err != nil {
+		t.Fatalf("DryRunSweep failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+
+	indexableCount := 0
+	for _, d := range results {
+		if d.Indexable {
+			indexableCount++
+			if d.MainPairs < 2 {
+				t.Errorf("session %s: indexable but mainPairs=%d", d.UUID, d.MainPairs)
+			}
+			if d.AssistantChars < 200 {
+				t.Errorf("session %s: indexable but chars=%d", d.UUID, d.AssistantChars)
+			}
+		}
+		if d.Size <= 0 {
+			t.Errorf("session %s: size=%d, want > 0", d.UUID, d.Size)
+		}
+	}
+	if indexableCount != 2 {
+		t.Errorf("got %d indexable sessions, want 2", indexableCount)
+	}
+}
+
+func TestDryRunSweep_AlreadyIndexed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-indexed")
+
+	dbPath := filepath.Join(projectDir, ".capy", "test.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-dryrun-indexed-32byt")
+
+	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	defer cs.Close()
+
+	ctx := context.Background()
+	_, err := indexSession(ctx, cs, sessionDir, "sess-indexed")
+	if err != nil {
+		t.Fatalf("indexSession failed: %v", err)
+	}
+
+	results, err := DryRunSweep(projectDir, cs, SweepOptions{})
+	if err != nil {
+		t.Fatalf("DryRunSweep failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if !results[0].AlreadyIndexed {
+		t.Error("expected session to be marked as already indexed")
+	}
+
+	// With Reindex, should NOT be marked as already indexed.
+	results2, err := DryRunSweep(projectDir, cs, SweepOptions{Reindex: true})
+	if err != nil {
+		t.Fatalf("DryRunSweep(reindex) failed: %v", err)
+	}
+	if results2[0].AlreadyIndexed {
+		t.Error("with Reindex=true, session should not be marked as already indexed")
+	}
+}
+
+func TestSweepWithOptions_Reindex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectDir := filepath.Join(home, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := manglePath(projectDir)
+	sessionDir := filepath.Join(home, ".claude", "projects", mangled)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestSession(t, sessionDir, "sess-reindex")
+
+	dbPath := filepath.Join(projectDir, ".capy", "test.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-reindex-sweep-32byte")
+
+	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	defer cs.Close()
+
+	ctx := context.Background()
+
+	// First sweep indexes the session.
+	indexed, _, errs := SweepWithOptions(ctx, cs, projectDir, SweepOptions{})
+	if indexed != 1 {
+		t.Fatalf("first sweep: indexed=%d, want 1", indexed)
+	}
+	if errs != 0 {
+		t.Fatalf("first sweep: errors=%d, want 0", errs)
+	}
+
+	// Reindex sweep re-processes even though the content hasn't changed.
+	// With content_hash dedup, the store updates access time but no error occurs.
+	indexed2, _, errs2 := SweepWithOptions(ctx, cs, projectDir, SweepOptions{Reindex: true})
+	if indexed2 != 1 {
+		t.Fatalf("reindex sweep: indexed=%d, want 1 (re-processed)", indexed2)
+	}
+	if errs2 != 0 {
+		t.Fatalf("reindex sweep: errors=%d, want 0", errs2)
+	}
+}


### PR DESCRIPTION
Provides diagnostics and manual control over the session sweep that
normally runs silently at MCP server startup. Dry-run mode (default)
prints a per-session table showing pairs, chars, and indexability
status. --force actually indexes, --reindex bypasses mtime checks
to re-parse all sessions (useful after parser bug fixes).

New: DryRunSweep, SweepOptions, SweepWithOptions in session package.

## Test Plan
make test

---

📚 **Stacked on:** #37 - Fix session parser discarding text from non-cumulative progressive snapshots

This PR is part of a stack and builds upon #37. Review and merge that PR first.