### PR TITLE
Document source kinds in routing instructions and expose session in search schema

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -57,6 +57,22 @@ Grep results can flood context. Use `capy_execute(language: "shell", code: "grep
 4. **WEB**: `capy_fetch_and_index(url, source)` then `capy_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
 5. **INDEX**: `capy_index(content, source)` — Store content in FTS5 knowledge base for later search.
 
+## Source kinds
+
+Every indexed entry has a **kind** that controls its lifecycle and search visibility:
+
+| Kind | What produces it | Retention | Included by default in search? |
+|------|-----------------|-----------|-------------------------------|
+| `durable` | `capy_index`, `capy_fetch_and_index` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
+| `ephemeral` | `capy_execute`, `capy_execute_file`, `capy_batch_execute` (auto-indexed output) | Strict TTL — swept after expiry | No |
+| `session` | `capy sweep` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+
+**Querying non-default kinds:** pass `include_kinds` to `capy_search`:
+- `include_kinds: ["durable", "ephemeral"]` — recover output from earlier commands in this session
+- `include_kinds: ["durable", "session"]` — search past conversation transcripts
+- `include_kinds: ["durable", "ephemeral", "session"]` — search everything
+- Or use `source: "<label>"` to bypass kind filtering entirely (matches any kind)
+
 ## Subagent routing
 
 When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -75,6 +75,22 @@ Grep results can flood context. Use ` + "`capy_execute(language: \"shell\", code
 4. **WEB**: ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + ` — Fetch, chunk, index, query. Raw HTML never enters context.
 5. **INDEX**: ` + "`capy_index(content, source)`" + ` — Store content in FTS5 knowledge base for later search.
 
+## Source kinds
+
+Every indexed entry has a **kind** that controls its lifecycle and search visibility:
+
+| Kind | What produces it | Retention | Included by default in search? |
+|------|-----------------|-----------|-------------------------------|
+| ` + "`durable`" + ` | ` + "`capy_index`" + `, ` + "`capy_fetch_and_index`" + ` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
+| ` + "`ephemeral`" + ` | ` + "`capy_execute`" + `, ` + "`capy_execute_file`" + `, ` + "`capy_batch_execute`" + ` (auto-indexed output) | Strict TTL — swept after expiry | No |
+| ` + "`session`" + ` | ` + "`capy sweep`" + ` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+
+**Querying non-default kinds:** pass ` + "`include_kinds`" + ` to ` + "`capy_search`" + `:
+- ` + "`include_kinds: [\"durable\", \"ephemeral\"]`" + ` — recover output from earlier commands in this session
+- ` + "`include_kinds: [\"durable\", \"session\"]`" + ` — search past conversation transcripts
+- ` + "`include_kinds: [\"durable\", \"ephemeral\", \"session\"]`" + ` — search everything
+- Or use ` + "`source: \"<label>\"`" + ` to bypass kind filtering entirely (matches any kind)
+
 ## Subagent routing
 
 When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -202,8 +202,8 @@ func toolSearch() mcp.Tool {
 			mcp.Description("Filter to a specific indexed source (partial match). When set, kind filtering is bypassed — caller's named source wins."),
 		),
 		mcp.WithArray("include_kinds",
-			mcp.Description("Source kinds to include. Accepted values: \"durable\" (fetched/indexed reference content) and \"ephemeral\" (auto-indexed command output from capy_execute / capy_execute_file / capy_batch_execute). Default: [\"durable\"] only. Use [\"durable\",\"ephemeral\"] to recover prior session command output."),
-			mcp.Items(map[string]any{"type": "string", "enum": []string{"durable", "ephemeral"}}),
+			mcp.Description("Source kinds to include. Accepted values: \"durable\" (fetched/indexed reference content, retained by retention score), \"ephemeral\" (auto-indexed command output from capy_execute / capy_execute_file / capy_batch_execute, swept by TTL), and \"session\" (past conversation transcripts indexed by `capy sweep`, swept by TTL). Default: [\"durable\"] only. Use [\"durable\",\"ephemeral\"] to recover prior command output, or [\"durable\",\"session\"] to search past conversations."),
+			mcp.Items(map[string]any{"type": "string", "enum": []string{"durable", "ephemeral", "session"}}),
 		),
 	)
 }


### PR DESCRIPTION
Models had no way to discover the session source kind — it was accepted by
the code but absent from the capy_search include_kinds enum and completely
missing from the generated routing instructions. This meant models would
never search past conversation transcripts unless they stumbled on a
runtime no-results hint.

## Test Plan
```bash
make test
make build
./capy setup --local
```