### PR TITLE
Fix --project-dir to accept Claude session directory paths

### DIFF
--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -20,6 +20,21 @@ func newSweepCmd() *cobra.Command {
 			projectDir, _ := cmd.Flags().GetString("project-dir")
 			if projectDir == "" {
 				projectDir = config.DetectProjectRoot()
+			} else {
+				res, err := config.ResolveSourceProject(projectDir)
+				if err != nil {
+					return err
+				}
+				if res.IsSessionDir && res.SourceDir != "" {
+					projectDir = res.SourceDir
+				} else if res.IsSessionDir {
+					// Source project no longer exists (renamed/deleted).
+					// Use the session directory directly — SessionDir will
+					// pass it through, and we use it for DB hashing too.
+					projectDir = res.SessionDir
+				} else {
+					projectDir = res.SourceDir
+				}
 			}
 
 			cfg, _ := config.Load(projectDir)

--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -25,15 +25,9 @@ func newSweepCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if res.IsSessionDir && res.SourceDir != "" {
-					projectDir = res.SourceDir
-				} else if res.IsSessionDir {
-					// Source project no longer exists (renamed/deleted).
-					// Use the session directory directly — SessionDir will
-					// pass it through, and we use it for DB hashing too.
+				projectDir = res.SourceDir
+				if res.IsSessionDir && res.SourceDir == "" {
 					projectDir = res.SessionDir
-				} else {
-					projectDir = res.SourceDir
 				}
 			}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -237,6 +237,16 @@ func TestUnmanglePath_DottedDir(t *testing.T) {
 	assert.Equal(t, projectDir, got)
 }
 
+func TestUnmanglePath_InteriorDot(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "my.repo", "sub")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	mangled := strings.NewReplacer("/", "-", ".", "-").Replace(projectDir)
+	got := unmanglePath(mangled)
+	assert.Equal(t, projectDir, got)
+}
+
 func TestUnmanglePath_NoMatch(t *testing.T) {
 	got := unmanglePath("-nonexistent-project-path")
 	assert.Empty(t, got)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -165,6 +166,85 @@ func TestLoadMalformedTOML(t *testing.T) {
 
 	_, err := Load(dir)
 	assert.Error(t, err)
+}
+
+func TestResolveSourceProject_RegularPath(t *testing.T) {
+	dir := t.TempDir()
+	res, err := ResolveSourceProject(dir)
+	require.NoError(t, err)
+	assert.Equal(t, dir, res.SourceDir)
+	assert.False(t, res.IsSessionDir)
+}
+
+func TestResolveSourceProject_SessionDir(t *testing.T) {
+	// Create a fake project directory structure:
+	// /tmp/.../a/b/my-project   (source project with a literal dash)
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "a", "b", "my-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	// Build the mangled name that Claude Code would produce.
+	mangled := strings.NewReplacer("/", "-", ".", "-").Replace(projectDir)
+
+	// Create the session directory under a fake HOME.
+	tmpHome := t.TempDir()
+	sessionDir := filepath.Join(tmpHome, ".claude", "projects", mangled)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	t.Setenv("HOME", tmpHome)
+
+	res, err := ResolveSourceProject(sessionDir)
+	require.NoError(t, err)
+	assert.True(t, res.IsSessionDir)
+	assert.Equal(t, projectDir, res.SourceDir)
+	assert.Equal(t, sessionDir, res.SessionDir)
+}
+
+func TestResolveSourceProject_SessionDir_OrphanedProject(t *testing.T) {
+	tmpHome := t.TempDir()
+	// A session directory whose source project no longer exists on disk.
+	sessionDir := filepath.Join(tmpHome, ".claude", "projects", "-gone-project-dir")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	t.Setenv("HOME", tmpHome)
+
+	res, err := ResolveSourceProject(sessionDir)
+	require.NoError(t, err)
+	assert.True(t, res.IsSessionDir)
+	assert.Empty(t, res.SourceDir)
+	assert.Equal(t, sessionDir, res.SessionDir)
+}
+
+func TestUnmanglePath(t *testing.T) {
+	// Build a real directory tree to probe against.
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "Projects", "claude-starter-kit")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	mangled := strings.NewReplacer("/", "-", ".", "-").Replace(projectDir)
+	got := unmanglePath(mangled)
+	assert.Equal(t, projectDir, got)
+}
+
+func TestUnmanglePath_DottedDir(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, ".hidden", "sub")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	mangled := strings.NewReplacer("/", "-", ".", "-").Replace(projectDir)
+	got := unmanglePath(mangled)
+	// Dots in directory names become "-", same as "/" — un-mangling may not
+	// recover the original if both /hidden/sub and .hidden/sub exist. But when
+	// only one exists, it should resolve.
+	assert.Equal(t, projectDir, got)
+}
+
+func TestUnmanglePath_NoMatch(t *testing.T) {
+	got := unmanglePath("-nonexistent-project-path")
+	assert.Empty(t, got)
+}
+
+func TestUnmanglePath_NoLeadingDash(t *testing.T) {
+	got := unmanglePath("relative-path")
+	assert.Empty(t, got)
 }
 
 func TestDetectProjectRoot(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -92,7 +92,7 @@ func ResolveSourceProject(projectDir string) (ProjectDirResolution, error) {
 
 	claudeDir, err := ClaudeProjectsDir()
 	if err != nil {
-		return ProjectDirResolution{SourceDir: abs}, nil
+		return ProjectDirResolution{}, fmt.Errorf("resolving claude projects dir: %w", err)
 	}
 
 	prefix := claudeDir + string(filepath.Separator)
@@ -120,9 +120,6 @@ func unmanglePath(mangled string) string {
 		return ""
 	}
 	parts := strings.Split(mangled[1:], "-")
-	if len(parts) == 0 {
-		return ""
-	}
 	return unmangledProbe("/", parts)
 }
 
@@ -131,9 +128,8 @@ func unmanglePath(mangled string) string {
 // directories. Tries shortest segments first with backtracking so that
 // literal dashes in directory names (e.g. "claude-starter-kit") are handled.
 //
-// Each "-" in the mangled name could have been "/", ".", or a literal "-".
-// The function tries "/" first (path separator), then "." (for hidden dirs
-// like .config), then "-" (literal dash in directory names).
+// Uses os.Stat (not os.ReadDir) because parent directories may not be
+// listable even when children are accessible — e.g. /var/folders/ on macOS.
 func unmangledProbe(prefix string, parts []string) string {
 	if len(parts) == 0 {
 		return prefix
@@ -141,7 +137,6 @@ func unmangledProbe(prefix string, parts []string) string {
 	for i := 1; i <= len(parts); i++ {
 		segment := strings.Join(parts[:i], "-")
 
-		// Try as a path component (the "-" was originally "/").
 		candidate := filepath.Join(prefix, segment)
 		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
 			if i == len(parts) {
@@ -152,9 +147,9 @@ func unmangledProbe(prefix string, parts []string) string {
 			}
 		}
 
-		// Try with a leading dot (the "-" before this segment was ".").
-		// Only when this is the first segment — a dot-prefixed directory
-		// like ".hidden" mangles to "-hidden", colliding with "/hidden".
+		// A dot-prefixed directory like ".hidden" mangles to "-hidden",
+		// colliding with a path separator. Try the dot variant for the
+		// first segment only (dots only appear at the start of a name).
 		if i == 1 {
 			dotCandidate := filepath.Join(prefix, "."+segment)
 			if info, err := os.Stat(dotCandidate); err == nil && info.IsDir() {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -3,9 +3,11 @@ package config
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // DetectProjectRoot finds the project root directory using:
@@ -54,6 +56,118 @@ func ProjectHash(dir string) string {
 	abs, _ := filepath.Abs(dir)
 	h := sha256.Sum256([]byte(abs))
 	return hex.EncodeToString(h[:8])
+}
+
+// ClaudeProjectsDir returns the path to ~/.claude/projects/.
+func ClaudeProjectsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "projects"), nil
+}
+
+// ProjectDirResolution holds the result of resolving a --project-dir value.
+type ProjectDirResolution struct {
+	// SourceDir is the original project directory on disk. Empty when the
+	// source could not be recovered (e.g. project was renamed/deleted).
+	SourceDir string
+	// SessionDir is the Claude Code session directory, set only when the
+	// input was detected as a session directory path.
+	SessionDir string
+	// IsSessionDir is true when the input was under ~/.claude/projects/.
+	IsSessionDir bool
+}
+
+// ResolveSourceProject normalizes a --project-dir value. If the given path is
+// a Claude Code session directory (under ~/.claude/projects/), it recovers the
+// original project path by probing the filesystem. When the source project no
+// longer exists on disk, the session directory is still returned so that sweep
+// can operate on orphaned sessions.
+func ResolveSourceProject(projectDir string) (ProjectDirResolution, error) {
+	abs, err := filepath.Abs(projectDir)
+	if err != nil {
+		return ProjectDirResolution{}, fmt.Errorf("resolving absolute path: %w", err)
+	}
+
+	claudeDir, err := ClaudeProjectsDir()
+	if err != nil {
+		return ProjectDirResolution{SourceDir: abs}, nil
+	}
+
+	prefix := claudeDir + string(filepath.Separator)
+	if !strings.HasPrefix(abs, prefix) {
+		return ProjectDirResolution{SourceDir: abs}, nil
+	}
+
+	rest := abs[len(prefix):]
+	mangled, _, _ := strings.Cut(rest, string(filepath.Separator))
+	sessDir := filepath.Join(claudeDir, mangled)
+
+	source := unmanglePath(mangled)
+	return ProjectDirResolution{
+		SourceDir:    source,
+		SessionDir:   sessDir,
+		IsSessionDir: true,
+	}, nil
+}
+
+// unmanglePath attempts to recover the original filesystem path from a
+// Claude Code mangled directory name (where / and . are replaced with -).
+// Returns "" if the original path cannot be determined.
+func unmanglePath(mangled string) string {
+	if !strings.HasPrefix(mangled, "-") {
+		return ""
+	}
+	parts := strings.Split(mangled[1:], "-")
+	if len(parts) == 0 {
+		return ""
+	}
+	return unmangledProbe("/", parts)
+}
+
+// unmangledProbe recursively builds a filesystem path by re-joining mangled
+// segments with "-" and checking which combinations correspond to existing
+// directories. Tries shortest segments first with backtracking so that
+// literal dashes in directory names (e.g. "claude-starter-kit") are handled.
+//
+// Each "-" in the mangled name could have been "/", ".", or a literal "-".
+// The function tries "/" first (path separator), then "." (for hidden dirs
+// like .config), then "-" (literal dash in directory names).
+func unmangledProbe(prefix string, parts []string) string {
+	if len(parts) == 0 {
+		return prefix
+	}
+	for i := 1; i <= len(parts); i++ {
+		segment := strings.Join(parts[:i], "-")
+
+		// Try as a path component (the "-" was originally "/").
+		candidate := filepath.Join(prefix, segment)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			if i == len(parts) {
+				return candidate
+			}
+			if result := unmangledProbe(candidate, parts[i:]); result != "" {
+				return result
+			}
+		}
+
+		// Try with a leading dot (the "-" before this segment was ".").
+		// Only when this is the first segment — a dot-prefixed directory
+		// like ".hidden" mangles to "-hidden", colliding with "/hidden".
+		if i == 1 {
+			dotCandidate := filepath.Join(prefix, "."+segment)
+			if info, err := os.Stat(dotCandidate); err == nil && info.IsDir() {
+				if i == len(parts) {
+					return dotCandidate
+				}
+				if result := unmangledProbe(dotCandidate, parts[i:]); result != "" {
+					return result
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // ResolveDBPath returns the path to the SQLite knowledge base.

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -124,41 +124,45 @@ func unmanglePath(mangled string) string {
 }
 
 // unmangledProbe recursively builds a filesystem path by re-joining mangled
-// segments with "-" and checking which combinations correspond to existing
-// directories. Tries shortest segments first with backtracking so that
-// literal dashes in directory names (e.g. "claude-starter-kit") are handled.
+// segments and checking which combinations correspond to existing directories.
+// Tries shortest segments first with backtracking so that literal dashes and
+// dots in directory names are handled correctly.
 //
-// Uses os.Stat (not os.ReadDir) because parent directories may not be
-// listable even when children are accessible — e.g. /var/folders/ on macOS.
+// Each "-" in the mangled name could originally have been "/", ".", or a
+// literal "-". For each grouping of parts the function tries "-" (literal
+// dash), "." (interior dot, e.g. "my.repo"), and "." as a leading prefix
+// (hidden dirs like ".config"). Uses os.Stat rather than os.ReadDir because
+// parent directories may not be listable on macOS (/var/folders/).
 func unmangledProbe(prefix string, parts []string) string {
 	if len(parts) == 0 {
 		return prefix
 	}
 	for i := 1; i <= len(parts); i++ {
-		segment := strings.Join(parts[:i], "-")
+		dashSegment := strings.Join(parts[:i], "-")
 
-		candidate := filepath.Join(prefix, segment)
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		candidates := []string{filepath.Join(prefix, dashSegment)}
+
+		if i > 1 {
+			dotSegment := strings.Join(parts[:i], ".")
+			candidates = append(candidates, filepath.Join(prefix, dotSegment))
+		}
+
+		// A dot-prefixed directory like ".hidden" mangles to "-hidden",
+		// colliding with a path separator.
+		if i == 1 {
+			candidates = append(candidates, filepath.Join(prefix, "."+dashSegment))
+		}
+
+		for _, candidate := range candidates {
+			info, err := os.Stat(candidate)
+			if err != nil || !info.IsDir() {
+				continue
+			}
 			if i == len(parts) {
 				return candidate
 			}
 			if result := unmangledProbe(candidate, parts[i:]); result != "" {
 				return result
-			}
-		}
-
-		// A dot-prefixed directory like ".hidden" mangles to "-hidden",
-		// colliding with a path separator. Try the dot variant for the
-		// first segment only (dots only appear at the start of a name).
-		if i == 1 {
-			dotCandidate := filepath.Join(prefix, "."+segment)
-			if info, err := os.Stat(dotCandidate); err == nil && info.IsDir() {
-				if i == len(parts) {
-					return dotCandidate
-				}
-				if result := unmangledProbe(dotCandidate, parts[i:]); result != "" {
-					return result
-				}
 			}
 		}
 	}

--- a/internal/session/sweep.go
+++ b/internal/session/sweep.go
@@ -16,20 +16,31 @@ import (
 // SessionDir returns the Claude Code session directory for the given project.
 // Claude Code mangles the absolute project path by replacing "/" and "." with "-"
 // and stores sessions under ~/.claude/projects/<mangled>/.
+//
+// If the given path is already under ~/.claude/projects/ (i.e. it is itself a
+// session directory), it is validated and returned directly without mangling.
 func SessionDir(projectDir string) (string, error) {
 	abs, err := filepath.Abs(projectDir)
 	if err != nil {
 		return "", fmt.Errorf("resolving absolute path: %w", err)
 	}
 
-	mangled := manglePath(abs)
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolving home directory: %w", err)
 	}
 
-	dir := filepath.Join(home, ".claude", "projects", mangled)
+	claudeDir := filepath.Join(home, ".claude", "projects")
+	prefix := claudeDir + string(filepath.Separator)
+
+	var dir string
+	if strings.HasPrefix(abs, prefix) {
+		dir = abs
+	} else {
+		mangled := manglePath(abs)
+		dir = filepath.Join(claudeDir, mangled)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil {
 		return "", fmt.Errorf("session directory not found: %w", err)


### PR DESCRIPTION
- Fix --project-dir to accept Claude session directory paths
  SessionDir always mangled its input, so passing a path already under
  ~/.claude/projects/ produced a double-mangled lookup that never matched.
  Add ResolveSourceProject to detect session directory inputs and recover
  the original project path via greedy filesystem probing (handles literal
  dashes and dot-prefixed directories). When the source project no longer
  exists on disk (renamed/deleted), the session directory is used directly.
  SessionDir now skips mangling when the input is already under the Claude
  projects tree.
- Address review findings: simplify conditional, return error, remove dead guard
  - Simplify sweep.go conditional to default-then-override pattern
  - Return error from ClaudeProjectsDir instead of silently falling back
  - Remove unreachable len(parts)==0 guard in unmanglePath
  - Keep stat-based unmangledProbe (ReadDir fails on macOS /var/folders/)
- Handle interior dots in directory names during path un-mangling
  unmangledProbe now tries "." as an interior separator (e.g. "my.repo")
  in addition to "-" (literal dash) and "." as a leading prefix (.hidden).
  Fixes silent fallback to orphaned-project path for dotted directory names.
- (chore) Update knowledge.db

## Test Plan
make test