### PR TITLE
(fix) Add source-size guard to prevent knowledge.db bloat

### DIFF
--- a/cmd/capy/checkpoint.go
+++ b/cmd/capy/checkpoint.go
@@ -48,7 +48,7 @@ has the DB open, the WAL cannot be fully truncated.`,
 			// We don't use ContentStore here because:
 			// 1. NewContentStore is lazy — Close() would no-op on an unopened store
 			// 2. database/sql's connection pool can interfere with checkpoint
-			st := store.NewContentStore(dbPath, projectDir, 0)
+			st := store.NewContentStore(dbPath, projectDir, 0, 0)
 			if err := st.Checkpoint(); err != nil {
 				return fmt.Errorf("checkpoint failed: %w", err)
 			}

--- a/cmd/capy/cleanup.go
+++ b/cmd/capy/cleanup.go
@@ -33,10 +33,39 @@ func newCleanupCmd() *cobra.Command {
 			if kind != "" && kind != "ephemeral" && kind != "session" {
 				return fmt.Errorf("invalid --kind value %q: accepted values are \"ephemeral\", \"session\"", kind)
 			}
+			sourceLabel, _ := cmd.Flags().GetString("source")
+			if sourceLabel != "" && kind != "" {
+				return fmt.Errorf("--source cannot be combined with --kind")
+			}
+
+			vacuum, _ := cmd.Flags().GetBool("vacuum")
 
 			dbPath := cfg.ResolveDBPath(projectDir)
-			st := store.NewContentStore(dbPath, projectDir, 0)
+			st := store.NewContentStore(dbPath, projectDir, 0, cfg.Store.MaxSourceBytes)
 			defer st.Close()
+
+			// Explicit vacuum only.
+			if vacuum && sourceLabel == "" && kind == "" && !force {
+				if err := st.Vacuum(); err != nil {
+					return fmt.Errorf("vacuum failed: %w", err)
+				}
+				fmt.Println("capy: vacuum complete")
+				return nil
+			}
+
+			// Source-specific eviction.
+			if sourceLabel != "" {
+				evicted, err := st.EvictByLabel(sourceLabel, dryRun)
+				if err != nil {
+					return fmt.Errorf("cleanup failed: %w", err)
+				}
+				action := "would remove"
+				if !dryRun {
+					action = "removed"
+				}
+				fmt.Printf("capy: %s source %q (%s, %d chunks)\n", action, evicted.Label, evicted.Kind, evicted.ChunkCount)
+				return nil
+			}
 
 			ephemeralTTL := time.Duration(cfg.Store.Cleanup.EphemeralTTLHours) * time.Hour
 			sessionTTL := time.Duration(cfg.Store.Cleanup.SessionTTLDays) * 24 * time.Hour
@@ -81,15 +110,23 @@ func newCleanupCmd() *cobra.Command {
 	cmd.Flags().Bool("dry-run", true, "show what would be removed without removing")
 	cmd.Flags().Bool("force", false, "actually remove stale data")
 	cmd.Flags().String("kind", "", "only clean up sources of this kind (\"ephemeral\" or \"session\")")
+	cmd.Flags().String("source", "", "evict a specific source by exact label")
+	cmd.Flags().Bool("vacuum", false, "run VACUUM to reclaim dead pages (auto-runs after cleanup when freelist > 20%%)")
 	return cmd
 }
 
 // formatCleanupDetail renders per-source eviction detail, switching between
 // retention-score framing and TTL-age framing based on EvictionReason.
 func formatCleanupDetail(s store.SourceInfo) string {
-	if s.EvictionReason == "ttl" {
+	switch s.EvictionReason {
+	case "ttl":
 		return fmt.Sprintf("reason: ttl, age: %s", time.Since(s.IndexedAt).Truncate(time.Minute))
+	case "oversized":
+		return fmt.Sprintf("reason: oversized, chunks: %d, kind: %s", s.ChunkCount, s.Kind)
+	case "manual":
+		return fmt.Sprintf("reason: manual, kind: %s, chunks: %d", s.Kind, s.ChunkCount)
+	default:
+		return fmt.Sprintf("reason: retention, score: %.2f, last accessed: %s",
+			s.RetentionScore, s.LastAccessedAt.Format("2006-01-02"))
 	}
-	return fmt.Sprintf("reason: retention, score: %.2f, last accessed: %s",
-		s.RetentionScore, s.LastAccessedAt.Format("2006-01-02"))
 }

--- a/cmd/capy/cleanup.go
+++ b/cmd/capy/cleanup.go
@@ -44,8 +44,8 @@ func newCleanupCmd() *cobra.Command {
 			st := store.NewContentStore(dbPath, projectDir, 0, cfg.Store.MaxSourceBytes)
 			defer st.Close()
 
-			// Explicit vacuum only.
-			if vacuum && sourceLabel == "" && kind == "" && !force {
+			// Explicit vacuum without cleanup.
+			if vacuum && !force && sourceLabel == "" && kind == "" {
 				if err := st.Vacuum(); err != nil {
 					return fmt.Errorf("vacuum failed: %w", err)
 				}
@@ -81,6 +81,16 @@ func newCleanupCmd() *cobra.Command {
 			}
 			if err != nil {
 				return fmt.Errorf("cleanup failed: %w", err)
+			}
+
+			// Explicit --vacuum with --force: always vacuum after cleanup,
+			// regardless of freelist ratio (auto-vacuum may have already run
+			// inside Cleanup if ratio > 20%, but the user asked explicitly).
+			if vacuum && !dryRun {
+				if err := st.Vacuum(); err != nil {
+					return fmt.Errorf("vacuum failed: %w", err)
+				}
+				fmt.Println("capy: vacuum complete")
 			}
 
 			if dryRun {

--- a/cmd/capy/dbsize.go
+++ b/cmd/capy/dbsize.go
@@ -34,11 +34,20 @@ func newDBSizeCmd() *cobra.Command {
 
 			fmt.Printf("Database: %s\n\n", dbPath)
 
-			fmt.Println("=== Table sizes (pages × page_size) ===")
-			fmt.Printf("  %-30s %10s %10s\n", "Table", "Pages", "Size")
-			fmt.Printf("  %-30s %10s %10s\n", "-----", "-----", "----")
-			for _, t := range breakdown.Tables {
-				fmt.Printf("  %-30s %10d %10s\n", t.Name, t.Pages, humanBytes(t.Bytes))
+			if breakdown.HasDBStat {
+				fmt.Println("=== Table sizes (pages × page_size) ===")
+				fmt.Printf("  %-30s %10s %10s\n", "Table", "Pages", "Size")
+				fmt.Printf("  %-30s %10s %10s\n", "-----", "-----", "----")
+				for _, t := range breakdown.Tables {
+					fmt.Printf("  %-30s %10d %10s\n", t.Name, t.Pages, humanBytes(t.Bytes))
+				}
+			} else {
+				fmt.Println("=== Table row counts (dbstat unavailable — per-table sizes require SQLITE_ENABLE_DBSTAT_VTAB) ===")
+				fmt.Printf("  %-30s %10s\n", "Table", "Rows")
+				fmt.Printf("  %-30s %10s\n", "-----", "----")
+				for _, t := range breakdown.Tables {
+					fmt.Printf("  %-30s %10d\n", t.Name, t.RowCount)
+				}
 			}
 			fmt.Println()
 

--- a/cmd/capy/dbsize.go
+++ b/cmd/capy/dbsize.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/serpro69/capy/internal/config"
+	"github.com/serpro69/capy/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newDBSizeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dbsize",
+		Short: "Show knowledge base disk usage breakdown",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectDir, _ := cmd.Flags().GetString("project-dir")
+			if projectDir == "" {
+				projectDir = config.DetectProjectRoot()
+			}
+
+			cfg, _ := config.Load(projectDir)
+			if cfg == nil {
+				cfg = config.DefaultConfig()
+			}
+
+			dbPath := cfg.ResolveDBPath(projectDir)
+			st := store.NewContentStore(dbPath, projectDir, 0, 0)
+			defer st.Close()
+
+			breakdown, err := st.DiskUsage()
+			if err != nil {
+				return fmt.Errorf("disk usage query failed: %w", err)
+			}
+
+			fmt.Printf("Database: %s\n\n", dbPath)
+
+			fmt.Println("=== Table sizes (pages × page_size) ===")
+			fmt.Printf("  %-30s %10s %10s\n", "Table", "Pages", "Size")
+			fmt.Printf("  %-30s %10s %10s\n", "-----", "-----", "----")
+			for _, t := range breakdown.Tables {
+				fmt.Printf("  %-30s %10d %10s\n", t.Name, t.Pages, humanBytes(t.Bytes))
+			}
+			fmt.Println()
+
+			fmt.Println("=== Content by kind ===")
+			fmt.Printf("  %-12s %8s %10s %12s\n", "Kind", "Sources", "Chunks", "ContentSize")
+			fmt.Printf("  %-12s %8s %10s %12s\n", "----", "-------", "------", "-----------")
+			for _, k := range breakdown.Kinds {
+				fmt.Printf("  %-12s %8d %10d %12s\n", k.Kind, k.Sources, k.Chunks, humanBytes(k.ContentBytes))
+			}
+			fmt.Println()
+
+			fmt.Println("=== Top 15 sources by content size ===")
+			fmt.Printf("  %-50s %-10s %8s %12s\n", "Label", "Kind", "Chunks", "Size")
+			fmt.Printf("  %-50s %-10s %8s %12s\n", "-----", "----", "------", "----")
+			for _, s := range breakdown.TopSources {
+				label := s.Label
+				if len(label) > 50 {
+					label = label[:47] + "..."
+				}
+				fmt.Printf("  %-50s %-10s %8d %12s\n", label, s.Kind, s.Chunks, humanBytes(s.ContentBytes))
+			}
+			fmt.Println()
+
+			fmt.Printf("=== Summary ===\n")
+			fmt.Printf("  DB file size:    %s\n", humanBytes(breakdown.DBFileSize))
+			fmt.Printf("  Page size:       %d\n", breakdown.PageSize)
+			fmt.Printf("  Total pages:     %d\n", breakdown.TotalPages)
+			fmt.Printf("  Freelist pages:  %d (%s reclaimable via VACUUM)\n",
+				breakdown.FreelistPages, humanBytes(breakdown.FreelistPages*breakdown.PageSize))
+			fmt.Printf("  Vocabulary:      %d terms\n", breakdown.VocabTerms)
+
+			return nil
+		},
+	}
+	return cmd
+}
+
+func humanBytes(b int64) string {
+	const (
+		KB = 1024
+		MB = 1024 * KB
+		GB = 1024 * MB
+	)
+	switch {
+	case b >= GB:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(GB))
+	case b >= MB:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(MB))
+	case b >= KB:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cmd/capy/main.go
+++ b/cmd/capy/main.go
@@ -37,6 +37,7 @@ func main() {
 		newEncryptCmd(),
 		newWhichCmd(),
 		newSweepCmd(),
+		newDBSizeCmd(),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/cmd/capy/main_test.go
+++ b/cmd/capy/main_test.go
@@ -170,7 +170,7 @@ func TestCheckpointSubcommand_WithDB(t *testing.T) {
 	))
 
 	// Create an encrypted WAL-mode DB through the store API.
-	st := store.NewContentStore(dbPath, dir, 0)
+	st := store.NewContentStore(dbPath, dir, 0, 0)
 	_, err := st.Index("# Test\n\nCheckpoint test content.", "cp-test", "", store.KindDurable)
 	require.NoError(t, err)
 	require.NoError(t, st.Close())
@@ -189,7 +189,7 @@ func TestCheckpointSubcommand_WithDB(t *testing.T) {
 	}
 
 	// Data must survive the checkpoint.
-	st2 := store.NewContentStore(dbPath, dir, 0)
+	st2 := store.NewContentStore(dbPath, dir, 0, 0)
 	defer st2.Close()
 	sources, err := st2.ListSources()
 	require.NoError(t, err)

--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -41,7 +41,7 @@ func newSweepCmd() *cobra.Command {
 			opts := session.SweepOptions{Reindex: reindex}
 
 			dbPath := cfg.ResolveDBPath(projectDir)
-			st := store.NewContentStore(dbPath, projectDir, 0)
+			st := store.NewContentStore(dbPath, projectDir, 0, 0)
 			defer st.Close()
 
 			if force {

--- a/docs/adr/011-conservative-cleanup-policy.md
+++ b/docs/adr/011-conservative-cleanup-policy.md
@@ -26,6 +26,8 @@ Do not port `cleanupStaleSources`. Keep the existing `Cleanup()` method which on
 - If aggressive cleanup is ever needed, add an `aggressive` flag to existing `Cleanup` rather than a separate method
 - DB size concerns are mitigated by tiered freshness reporting in `capy_stats` — users can see what's cold and manually clean up
 
+**Amendment (2026-05-11):** Cleanup now also evicts sources whose total content size exceeds the configured `MaxSourceBytes` limit (default 2 MB), regardless of access count or retention score. This corrects sources that should never have been indexed at the current limit — see ADR-022. Auto-VACUUM triggers when freelist pages exceed 20% of total pages after a non-dry-run cleanup. The conservative never-accessed-only eviction principle is preserved for normally-sized durable sources.
+
 ## Consequences
 
 - capy's knowledge base may grow larger than context-mode's over time

--- a/docs/adr/022-source-size-guard-and-db-bloat-prevention.md
+++ b/docs/adr/022-source-size-guard-and-db-bloat-prevention.md
@@ -1,0 +1,136 @@
+# ADR-022: Source-size guard and DB bloat prevention
+
+**Status:** Accepted
+**Date:** 2026-05-11
+**Amends:** ADR-011 (conservative cleanup policy), ADR-017 (source-kind separation)
+**Issue:** [#43](https://github.com/serpro69/capy/issues/43)
+
+## Context
+
+`knowledge.db` grew to 88 MB with only 125 sources / 1572 chunks. Investigation revealed the bloat came from three compounding factors:
+
+1. **No content-size guard on `store.Index`/`store.IndexChunked`.** The `content` parameter on `capy_index` and auto-index paths from `capy_execute`/`capy_batch_execute` accepted unbounded input. A single 10 MB source made it through.
+2. **Trigram FTS index explosion.** FTS5 trigram tokenization has superlinear index growth. A 12 MB source produced ~42 MB of trigram index data.
+3. **Freelist accumulation.** Deleted rows leave dead pages that SQLite never returns without an explicit `VACUUM`.
+
+The per-chunk size (`MaxChunkBytes = 4096`) was fine — the problem was no cap on **total source size**, so a single source could produce 2500+ chunks, each individually reasonable but collectively devastating to the trigram index.
+
+### Entry points and their guards (before this change)
+
+| Entry point | Size guard | Applies to |
+|---|---|---|
+| `capy_index` (path param) | 10 MB file check | file reads only |
+| `capy_index` (content param) | **none** | inline content from LLM |
+| `capy_fetch_and_index` | 10 MB body limit | HTTP responses |
+| `capy_execute` / `capy_batch_execute` | **none** | auto-indexed command output |
+| `IndexChunked` (session sweep) | **none** | conversation transcripts |
+
+## Decision
+
+### 1. Single size gate at the store layer
+
+Add a `MaxSourceBytes` check in `store.Index()` and `store.IndexChunked()` — the two entry points through which all content reaches the FTS5 tables. This catches every caller (MCP tools, CLI commands, session sweep) without per-handler whack-a-mole.
+
+**Default:** 2 MB. Configurable via `store.max_source_bytes` in `.capy.toml`.
+
+**Behavior:** Hard reject with a typed `SourceTooLargeError` that includes the content size, the limit, and a pointer to the config key. Not truncation — silent truncation would make search lie about having indexed the full source.
+
+### 2. No trigram skip (deferred)
+
+The issue proposed a second threshold (`TrigramSkipBytes = 512 KB`) where sources above it get porter-only indexing (no trigram). We dropped this from the initial fix because:
+
+- The 2 MB cap already bounds the worst-case trigram growth per source to ~8 MB — manageable.
+- Two thresholds add complexity: partial indexing states, cleanup handling mixed porter/trigram sources, size-dependent search behavior.
+- The aggregate scenario (many 1.5 MB sources) is theoretical at current usage patterns.
+
+If aggregate trigram growth becomes a real problem, the skip can be added later with usage data to justify the complexity.
+
+### 3. Retroactive cleanup of oversized sources
+
+`Cleanup()` now runs an oversized-eviction pass **before** the existing retention-score and TTL passes. Sources whose total content size (summed across chunks) exceeds `MaxSourceBytes` are flagged as evictable with reason `"oversized"`, regardless of retention score, access count, or kind.
+
+This is implemented in cleanup rather than as a migration because:
+- Migrations should be schema-only; silently deleting user-indexed content on startup is too aggressive.
+- Cleanup is the "reduce DB size" path — users expect it to remove things.
+- Cleanup supports `--dry-run` (default), so users see what would happen before committing.
+
+### 4. Manual source eviction (`cleanup --source`)
+
+`EvictByLabel(label, dryRun)` force-evicts a specific source by exact label match, regardless of retention score, TTL, or access count. Exposed via both the MCP `capy_cleanup` tool (`source` parameter) and the CLI (`capy cleanup --source <label>`).
+
+### 5. Auto-VACUUM after cleanup
+
+After a non-dry-run cleanup that evicts at least one source, `Cleanup()` checks the freelist ratio. If freelist pages exceed 20% of total pages, it runs `VACUUM` automatically. With SQLCipher, VACUUM re-encrypts the entire DB, so it's heavier than plain SQLite — the 20% threshold avoids triggering it on small evictions.
+
+An explicit `capy cleanup --vacuum` flag is also available for manual use.
+
+### 6. `capy dbsize` diagnostic subcommand
+
+New CLI command showing table-level page counts, content-by-kind breakdown, top 15 sources by content size, freelist stats, and vocabulary size. Essential for diagnosing bloat and verifying cleanup results.
+
+## Variants Considered
+
+### Trigram skip at 512 KB
+
+Skip `chunks_trigram` insertion for sources between 512 KB and 2 MB. This would turn index growth from superlinear to linear for large sources.
+
+**Deferred.** Adds implementation complexity (two thresholds, partial index states, cleanup must handle mixed porter/trigram) for a scenario the 2 MB cap already makes unlikely. Can be revisited with data.
+
+### Truncation instead of rejection
+
+Silently truncate oversized content to the limit instead of rejecting.
+
+**Rejected.** Truncation makes search lie — a user who indexes a 5 MB document and searches for content in the last 3 MB would get no results with no explanation why. Hard rejection with a clear error message is more honest and actionable.
+
+### Per-handler size guards
+
+Add size checks in each tool handler (`handleIndex`, `handleBatchExecute`, `handleFetchAndIndex`, etc.) instead of at the store layer.
+
+**Rejected.** Five write sites today, more possible in the future. A store-level gate is a single chokepoint that catches every caller including future ones. Per-handler guards are defense-in-depth only — `tool_index.go` retains its file-size early-out to avoid reading a large file into memory just to have `store.Index` reject it.
+
+### Migration-based cleanup of existing oversized sources
+
+Run a one-shot migration on DB open that deletes sources exceeding the new limit.
+
+**Rejected.** Migrations should be schema-only. Silently deleting user-indexed content on startup without visibility or consent is too aggressive. Cleanup with `--dry-run` default gives users control.
+
+## Consequences
+
+**Positive**
+
+- DB bloat is bounded: no single source can produce more than ~8 MB of trigram index (down from unbounded).
+- Existing bloated databases are fixed by the next `capy cleanup --force` or periodic cleanup run.
+- Users can diagnose DB size issues with `capy dbsize` and surgically remove specific sources with `cleanup --source`.
+- Dead pages are reclaimed automatically when significant.
+
+**Negative / trade-offs**
+
+- Content > 2 MB is now rejected. Users must pre-filter or split large documents. The error message explains the limit and points to the config key.
+- `tool_index.go` file-read guard drops from 10 MB to 2 MB, matching the store-level cap. Users who previously indexed large files via path will now get a rejection.
+- Auto-VACUUM after cleanup adds latency (SQLCipher re-encryption) — bounded by the 20% threshold.
+
+**Cross-reference**
+
+- ADR-006 (persistence) — unchanged.
+- ADR-011 (conservative cleanup) — **amended**: cleanup now also evicts oversized sources regardless of access count, and auto-vacuums when freelist > 20%.
+- ADR-016 (WAL + checkpoint) — VACUUM interacts with WAL; the dedicated single-connection pattern from Checkpoint is reused.
+- ADR-017 (source-kind separation) — oversized eviction runs across all kinds, before kind-specific passes.
+
+## Configuration
+
+```toml
+[store]
+max_source_bytes = 2097152  # 2 MB, default
+```
+
+## CLI changes
+
+```
+capy cleanup --source <label>   # evict a specific source by exact label
+capy cleanup --vacuum           # run VACUUM to reclaim dead pages
+capy dbsize                     # show disk usage breakdown
+```
+
+## MCP changes
+
+`capy_cleanup` tool gains a `source` string parameter for source-specific eviction.

--- a/docs/wip/issue-43-db-bloat/tasks.md
+++ b/docs/wip/issue-43-db-bloat/tasks.md
@@ -1,0 +1,69 @@
+# Issue #43 — knowledge.db bloat fix
+
+## Task 1: MaxSourceBytes gate in store.Index + store.IndexChunked
+**Status:** done
+**Dependencies:** none
+
+- [ ] Add `DefaultMaxSourceBytes = 2 * 1024 * 1024` constant in `internal/store/`
+- [ ] Add typed `SourceTooLargeError` with size and limit fields
+- [ ] Add `maxSourceBytes` field to `ContentStore`, set from config in constructor
+- [ ] Gate `indexPreparedChunks` — reject before chunking if `len(content) > maxSourceBytes`
+- [ ] Gate `IndexChunked` — reject before entering `indexPreparedChunks` if `len(transcript) > maxSourceBytes`
+- [ ] Update `NewContentStore` signature to accept `maxSourceBytes` (0 = default)
+- [ ] Update all `NewContentStore` callers
+
+## Task 2: Config field store.max_source_bytes
+**Status:** done
+**Dependencies:** Task 1
+
+- [ ] Add `MaxSourceBytes int` to `StoreConfig` in `internal/config/config.go`
+- [ ] Set default to `2 * 1024 * 1024` in `DefaultConfig()`
+- [ ] Thread config value through to `NewContentStore` in server setup
+- [ ] Validate: values <= 0 fall back to default (not disabled)
+
+## Task 3: Lower tool_index.go file-read guard to 2 MB
+**Status:** done
+**Dependencies:** Task 1
+
+- [ ] Change `maxFileSize` from `10 * 1024 * 1024` to `2 * 1024 * 1024` in `tool_index.go`
+- [ ] Update error message to reference configurable `store.max_source_bytes`
+- [ ] Surface `SourceTooLargeError` from `store.Index` call with clear user message
+
+## Task 4: Threshold-aware cleanup — evict existing oversized sources
+**Status:** done
+**Dependencies:** Task 1, Task 2
+
+- [ ] In `Cleanup`, after normal eviction passes, scan durable sources for `content_size > MaxSourceBytes`
+- [ ] Need a way to compute source content size — add query or use `SUM(LENGTH(c.content))` join
+- [ ] Flag oversized sources as evictable with reason `"oversized"`
+- [ ] Respect `dryRun` — show what would be evicted
+- [ ] Update cleanup output formatting to include oversized reason
+
+## Task 5: cleanup --source \<label\> (MCP + CLI)
+**Status:** done
+**Dependencies:** Task 4
+
+- [ ] Add `EvictByLabel(label string, dryRun bool)` method to `ContentStore`
+- [ ] Add `source` string parameter to `capy_cleanup` MCP tool
+- [ ] Add `--source` flag to `capy cleanup` CLI command
+- [ ] Error clearly if label not found
+
+## Task 6: VACUUM after cleanup when freelist > 20%
+**Status:** done
+**Dependencies:** Task 4
+
+- [ ] Add `Vacuum()` method to `ContentStore` (opens dedicated connection like `Checkpoint`)
+- [ ] Add `FreelistRatio()` method — returns freelist_count / page_count
+- [ ] After `Cleanup` eviction (non-dry-run, non-zero evictions), check freelist ratio
+- [ ] Auto-VACUUM if ratio > 0.20
+- [ ] Add `--vacuum` flag to CLI cleanup for explicit trigger
+- [ ] Log VACUUM duration (SQLCipher re-encrypts entire DB)
+
+## Task 7: capy dbsize subcommand
+**Status:** done
+**Dependencies:** Task 1
+
+- [ ] Add `internal/store/diskusage.go` with `DiskUsage()` method (from issue body)
+- [ ] Add `cmd/capy/dbsize.go` with `newDBSizeCmd()` (from issue body)
+- [ ] Wire into `root.AddCommand()` in `cmd/capy/main.go`
+- [ ] Add `humanBytes` helper

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,11 @@ type Config struct {
 
 // StoreConfig controls the FTS5 knowledge base.
 type StoreConfig struct {
-	Path        string        `toml:"path"`
-	TitleWeight float64       `toml:"title_weight"` // BM25 title weight (default 2.0)
-	Cleanup     CleanupConfig `toml:"cleanup"`
-	Cache       CacheConfig   `toml:"cache"`
+	Path           string        `toml:"path"`
+	TitleWeight    float64       `toml:"title_weight"`     // BM25 title weight (default 2.0)
+	MaxSourceBytes int           `toml:"max_source_bytes"` // hard cap on total content per source (default 2 MB)
+	Cleanup        CleanupConfig `toml:"cleanup"`
+	Cache          CacheConfig   `toml:"cache"`
 }
 
 // CacheConfig controls fetch TTL caching.
@@ -50,7 +51,8 @@ type ServerConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Store: StoreConfig{
-			TitleWeight: 2.0,
+			TitleWeight:    2.0,
+			MaxSourceBytes: 2 * 1024 * 1024,
 			Cleanup: CleanupConfig{
 				ColdThresholdDays: 30,
 				EphemeralTTLHours: 24,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -102,6 +102,9 @@ func mergeConfig(dst, src *Config) {
 	if src.Store.TitleWeight != 0 {
 		dst.Store.TitleWeight = src.Store.TitleWeight
 	}
+	if src.Store.MaxSourceBytes != 0 {
+		dst.Store.MaxSourceBytes = src.Store.MaxSourceBytes
+	}
 	if src.Store.Cleanup.ColdThresholdDays != 0 {
 		dst.Store.Cleanup.ColdThresholdDays = src.Store.Cleanup.ColdThresholdDays
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,7 +81,7 @@ func NewServer(
 func (s *Server) getStore() *store.ContentStore {
 	s.storeMu.Do(func() {
 		dbPath := s.config.ResolveDBPath(s.projectDir)
-		s.store = store.NewContentStore(dbPath, s.projectDir, s.config.Store.TitleWeight)
+		s.store = store.NewContentStore(dbPath, s.projectDir, s.config.Store.TitleWeight, s.config.Store.MaxSourceBytes)
 	})
 	return s.store
 }

--- a/internal/server/tool_cleanup.go
+++ b/internal/server/tool_cleanup.go
@@ -80,6 +80,7 @@ func (s *Server) handleCleanup(_ context.Context, req mcp.CallToolRequest) (*mcp
 	for _, src := range pruned {
 		if src.EvictionReason == "oversized" {
 			oversizedN++
+			continue
 		}
 		switch src.Kind {
 		case store.KindSession:

--- a/internal/server/tool_cleanup.go
+++ b/internal/server/tool_cleanup.go
@@ -18,6 +18,7 @@ func (s *Server) handleCleanup(_ context.Context, req mcp.CallToolRequest) (*mcp
 			dryRun = b
 		}
 	}
+	sourceLabel := req.GetString("source", "")
 	purgeEphemeral := false
 	if v, ok := args["purge_ephemeral"]; ok {
 		if b, ok := v.(bool); ok {
@@ -34,8 +35,26 @@ func (s *Server) handleCleanup(_ context.Context, req mcp.CallToolRequest) (*mcp
 	if purgeEphemeral && purgeSession {
 		return errorResult("purge_ephemeral and purge_session are mutually exclusive"), nil
 	}
+	if sourceLabel != "" && (purgeEphemeral || purgeSession) {
+		return errorResult("source cannot be combined with purge_ephemeral or purge_session"), nil
+	}
 
 	st := s.getStore()
+
+	// Source-specific eviction: single source by exact label.
+	if sourceLabel != "" {
+		evicted, err := st.EvictByLabel(sourceLabel, dryRun)
+		if err != nil {
+			return errorResult(fmt.Sprintf("Cleanup error: %v", err)), nil
+		}
+		action := "would be removed"
+		if !dryRun {
+			action = "removed"
+		}
+		text := fmt.Sprintf("Source %q (%s, %d chunks) %s.", evicted.Label, evicted.Kind, evicted.ChunkCount, action)
+		return s.trackToolResponse("capy_cleanup", textResult(text)), nil
+	}
+
 	ephTTL := s.ephemeralTTL()
 	sessTTL := s.sessionTTL()
 	var pruned []store.SourceInfo
@@ -57,8 +76,11 @@ func (s *Server) handleCleanup(_ context.Context, req mcp.CallToolRequest) (*mcp
 			textResult("No evictable sources found.")), nil
 	}
 
-	var durableN, ephemeralN, sessionN int
+	var durableN, ephemeralN, sessionN, oversizedN int
 	for _, src := range pruned {
+		if src.EvictionReason == "oversized" {
+			oversizedN++
+		}
 		switch src.Kind {
 		case store.KindSession:
 			sessionN++
@@ -77,7 +99,16 @@ func (s *Server) handleCleanup(_ context.Context, req mcp.CallToolRequest) (*mcp
 	case purgeSession:
 		heading = "Cleanup (session purge)"
 	}
-	summary := fmt.Sprintf("%d durable (retention), %d ephemeral (TTL), %d session (TTL)", durableN, ephemeralN, sessionN)
+	var parts []string
+	if oversizedN > 0 {
+		parts = append(parts, fmt.Sprintf("%d oversized", oversizedN))
+	}
+	parts = append(parts,
+		fmt.Sprintf("%d durable (retention)", durableN),
+		fmt.Sprintf("%d ephemeral (TTL)", ephemeralN),
+		fmt.Sprintf("%d session (TTL)", sessionN),
+	)
+	summary := strings.Join(parts, ", ")
 	if dryRun {
 		lines = append(lines, fmt.Sprintf("## %s preview (dry run) — %d sources would be removed: %s", heading, len(pruned), summary))
 	} else {

--- a/internal/server/tool_index.go
+++ b/internal/server/tool_index.go
@@ -33,13 +33,16 @@ func (s *Server) handleIndex(_ context.Context, req mcp.CallToolRequest) (*mcp.C
 			}
 			path = cleanPath
 		}
-		const maxFileSize = 10 * 1024 * 1024 // 10MB
+		maxFileSize := int64(s.config.Store.MaxSourceBytes)
+		if maxFileSize <= 0 {
+			maxFileSize = int64(store.DefaultMaxSourceBytes)
+		}
 		info, err := os.Stat(path)
 		if err != nil {
 			return errorResult(fmt.Sprintf("Failed to read file: %v", err)), nil
 		}
 		if info.Size() > maxFileSize {
-			return errorResult(fmt.Sprintf("File too large (>%dMB)", maxFileSize/(1024*1024))), nil
+			return errorResult(fmt.Sprintf("File too large: %d bytes exceeds %d byte limit (configure store.max_source_bytes to adjust)", info.Size(), maxFileSize)), nil
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -269,9 +269,12 @@ func toolDoctor() mcp.Tool {
 func toolCleanup() mcp.Tool {
 	return mcp.NewTool("capy_cleanup",
 		mcp.WithToolAnnotation(annotationCleanup),
-		mcp.WithDescription("Clean up evictable knowledge base entries. By default runs three paths: retention-score eviction for durable sources, strict TTL eviction for ephemeral sources, and strict TTL eviction for session sources. Set purge_ephemeral=true or purge_session=true for kind-specific purges that skip other paths."),
+		mcp.WithDescription("Clean up evictable knowledge base entries. By default runs four paths: oversized source eviction, retention-score eviction for durable sources, strict TTL eviction for ephemeral sources, and strict TTL eviction for session sources. Set purge_ephemeral=true or purge_session=true for kind-specific purges, or source=<label> to evict a specific source."),
 		mcp.WithBoolean("dry_run",
 			mcp.Description("Preview what would be removed without deleting (default: true)"),
+		),
+		mcp.WithString("source",
+			mcp.Description("Evict a specific source by exact label, regardless of retention score or TTL"),
 		),
 		mcp.WithBoolean("purge_ephemeral",
 			mcp.Description("When true, only evict ephemeral sources past the TTL window; durable and session sources are untouched (default: false)"),

--- a/internal/session/sweep_test.go
+++ b/internal/session/sweep_test.go
@@ -231,7 +231,7 @@ func TestIndexSession_Integration(t *testing.T) {
 	dbPath := filepath.Join(tmp, "test.db")
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-sweep-integration-32b")
 
-	cs := store.NewContentStore(dbPath, tmp, 2.0)
+	cs := store.NewContentStore(dbPath, tmp, 2.0, 0)
 	defer cs.Close()
 
 	ctx := context.Background()
@@ -299,7 +299,7 @@ func TestSweep_ContextCancellation(t *testing.T) {
 	dbPath := filepath.Join(tmp, "test.db")
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-sweep-cancel-test-32")
 
-	cs := store.NewContentStore(dbPath, tmp, 2.0)
+	cs := store.NewContentStore(dbPath, tmp, 2.0, 0)
 	defer cs.Close()
 
 	// Cancel immediately.
@@ -335,7 +335,7 @@ func TestSweep_NonTrivialZeroTurns(t *testing.T) {
 	dbPath := filepath.Join(tmp, "test.db")
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-degradation-test-32")
 
-	cs := store.NewContentStore(dbPath, tmp, 2.0)
+	cs := store.NewContentStore(dbPath, tmp, 2.0, 0)
 	defer cs.Close()
 
 	// Should not error — just silently skip the non-indexable session.
@@ -413,7 +413,7 @@ func TestSweep_Orchestrator(t *testing.T) {
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-sweep-orchestrator-32")
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	cs := store.NewContentStore(dbPath, projectDir, 2.0, 0)
 	defer cs.Close()
 
 	// First sweep: should index 2 valid sessions, skip trivial.
@@ -574,7 +574,7 @@ func TestSweep_SecretSanitization(t *testing.T) {
 	dbPath := filepath.Join(tmp, "test.db")
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-secret-sanitize-test")
 
-	cs := store.NewContentStore(dbPath, tmp, 2.0)
+	cs := store.NewContentStore(dbPath, tmp, 2.0, 0)
 	defer cs.Close()
 
 	ok, err := indexSession(context.Background(), cs, tmp, uuid)
@@ -646,7 +646,7 @@ func TestSweep_SecretSanitization_MultiWindow(t *testing.T) {
 	dbPath := filepath.Join(tmp, "test.db")
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-multiwindow-secret-test")
 
-	cs := store.NewContentStore(dbPath, tmp, 2.0)
+	cs := store.NewContentStore(dbPath, tmp, 2.0, 0)
 	defer cs.Close()
 
 	ok, err := indexSession(context.Background(), cs, tmp, uuid)
@@ -756,7 +756,7 @@ func TestDryRunSweep_AlreadyIndexed(t *testing.T) {
 	}
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-dryrun-indexed-32byt")
 
-	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	cs := store.NewContentStore(dbPath, projectDir, 2.0, 0)
 	defer cs.Close()
 
 	ctx := context.Background()
@@ -814,7 +814,7 @@ func TestSweepWithOptions_Reindex(t *testing.T) {
 	}
 	t.Setenv("CAPY_ENCRYPTION_KEY", "test-key-for-reindex-sweep-32byte")
 
-	cs := store.NewContentStore(dbPath, projectDir, 2.0)
+	cs := store.NewContentStore(dbPath, projectDir, 2.0, 0)
 	defer cs.Close()
 
 	ctx := context.Background()

--- a/internal/store/bloat_guard_test.go
+++ b/internal/store/bloat_guard_test.go
@@ -1,0 +1,292 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SourceTooLargeError ---
+
+func TestSourceTooLargeError_Message(t *testing.T) {
+	err := &SourceTooLargeError{Size: 3_000_000, Limit: 2_097_152}
+	msg := err.Error()
+	assert.Contains(t, msg, "source too large")
+	assert.Contains(t, msg, "3000000 bytes")
+	assert.Contains(t, msg, "2097152 byte limit")
+	assert.Contains(t, msg, "store.max_source_bytes")
+}
+
+func TestSourceTooLargeError_ErrorsAs(t *testing.T) {
+	err := &SourceTooLargeError{Size: 5, Limit: 3}
+	var target *SourceTooLargeError
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, 5, target.Size)
+	assert.Equal(t, 3, target.Limit)
+}
+
+// --- Index size gate ---
+
+func TestIndex_RejectsOversizedContent(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	limit := 1024
+	s := NewContentStore(dbPath, dir, 0, limit)
+	t.Cleanup(func() { s.Close() })
+
+	content := strings.Repeat("a", limit+1)
+	_, err := s.Index(content, "too-big", "", KindDurable)
+	require.Error(t, err)
+
+	var sErr *SourceTooLargeError
+	require.ErrorAs(t, err, &sErr)
+	assert.Equal(t, limit+1, sErr.Size)
+	assert.Equal(t, limit, sErr.Limit)
+}
+
+func TestIndex_AcceptsContentAtLimit(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	limit := 2048
+	s := NewContentStore(dbPath, dir, 0, limit)
+	t.Cleanup(func() { s.Close() })
+
+	content := strings.Repeat("a", limit)
+	result, err := s.Index(content, "just-right", "", KindDurable)
+	require.NoError(t, err)
+	assert.Greater(t, result.TotalChunks, 0)
+}
+
+func TestIndex_AcceptsContentUnderLimit(t *testing.T) {
+	s := newTestStore(t)
+	content := "small content"
+	result, err := s.Index(content, "small", "", KindDurable)
+	require.NoError(t, err)
+	assert.Equal(t, "small", result.Label)
+}
+
+// --- IndexChunked size gate ---
+
+func TestIndexChunked_RejectsOversizedTranscript(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	limit := 512
+	s := NewContentStore(dbPath, dir, 0, limit)
+	t.Cleanup(func() { s.Close() })
+
+	transcript := strings.Repeat("x", limit+1)
+	chunks := []Chunk{{Title: "test", Content: "chunk"}}
+	_, err := s.IndexChunked(transcript, "chunked-too-big", "plaintext", KindSession, chunks)
+	require.Error(t, err)
+
+	var sErr *SourceTooLargeError
+	require.ErrorAs(t, err, &sErr)
+}
+
+func TestIndexChunked_AcceptsTranscriptAtLimit(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	limit := 1024
+	s := NewContentStore(dbPath, dir, 0, limit)
+	t.Cleanup(func() { s.Close() })
+
+	transcript := strings.Repeat("x", limit)
+	chunks := []Chunk{{Title: "ok", Content: "data"}}
+	result, err := s.IndexChunked(transcript, "chunked-ok", "plaintext", KindSession, chunks)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.TotalChunks)
+}
+
+// --- DefaultMaxSourceBytes ---
+
+func TestNewContentStore_DefaultsMaxSourceBytes(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	s := NewContentStore(dbPath, dir, 0, 0)
+	defer s.Close()
+	assert.Equal(t, DefaultMaxSourceBytes, s.maxSourceBytes)
+}
+
+func TestNewContentStore_CustomMaxSourceBytes(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	s := NewContentStore(dbPath, dir, 0, 4096)
+	defer s.Close()
+	assert.Equal(t, 4096, s.maxSourceBytes)
+}
+
+// --- Cleanup oversized eviction ---
+
+func TestCleanup_EvictsOversizedSources(t *testing.T) {
+	t.Setenv(encryptionKeyEnv, testEncryptionKey)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create store with a high limit to index large content.
+	s := NewContentStore(dbPath, dir, 0, 100_000)
+	_, err := s.Index(strings.Repeat("big ", 5000), "big-source", "", KindDurable)
+	require.NoError(t, err)
+	_, err = s.Index("small content", "small-source", "", KindDurable)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	// Reopen with a smaller limit so "big-source" is now oversized.
+	s2 := NewContentStore(dbPath, dir, 0, 1024)
+	t.Cleanup(func() { s2.Close() })
+
+	// Dry run should report the oversized source.
+	pruned, err := s2.Cleanup(true, 24*time.Hour, 60*24*time.Hour)
+	require.NoError(t, err)
+
+	var oversizedLabels []string
+	for _, src := range pruned {
+		if src.EvictionReason == "oversized" {
+			oversizedLabels = append(oversizedLabels, src.Label)
+		}
+	}
+	assert.Contains(t, oversizedLabels, "big-source")
+	assert.NotContains(t, oversizedLabels, "small-source")
+
+	// Verify source still exists (dry run).
+	sources, err := s2.ListSources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 2)
+
+	// Actual eviction.
+	pruned, err = s2.Cleanup(false, 24*time.Hour, 60*24*time.Hour)
+	require.NoError(t, err)
+
+	sources, err = s2.ListSources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 1)
+	assert.Equal(t, "small-source", sources[0].Label)
+}
+
+// --- EvictByLabel ---
+
+func TestEvictByLabel_RemovesSource(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Index("content to evict", "evict-me", "", KindDurable)
+	require.NoError(t, err)
+
+	evicted, err := s.EvictByLabel("evict-me", false)
+	require.NoError(t, err)
+	assert.Equal(t, "evict-me", evicted.Label)
+	assert.Equal(t, "manual", evicted.EvictionReason)
+
+	sources, err := s.ListSources()
+	require.NoError(t, err)
+	assert.Empty(t, sources)
+}
+
+func TestEvictByLabel_DryRun(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Index("content to keep", "keep-me", "", KindDurable)
+	require.NoError(t, err)
+
+	evicted, err := s.EvictByLabel("keep-me", true)
+	require.NoError(t, err)
+	assert.Equal(t, "keep-me", evicted.Label)
+
+	// Source should still exist.
+	sources, err := s.ListSources()
+	require.NoError(t, err)
+	assert.Len(t, sources, 1)
+}
+
+func TestEvictByLabel_NotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.EvictByLabel("nonexistent", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source not found")
+}
+
+// --- FreelistRatio ---
+
+func TestFreelistRatio_ReturnsNonNegative(t *testing.T) {
+	s := newTestStore(t)
+
+	// Force DB initialization.
+	_, err := s.Index("init content", "init", "", KindDurable)
+	require.NoError(t, err)
+
+	ratio := s.FreelistRatio()
+	assert.GreaterOrEqual(t, ratio, 0.0)
+	assert.LessOrEqual(t, ratio, 1.0)
+}
+
+// --- Vacuum ---
+
+func TestVacuum_RunsWithoutError(t *testing.T) {
+	s := newTestStore(t)
+
+	// Index and delete to create freelist pages.
+	_, err := s.Index(strings.Repeat("data ", 1000), "vacuum-test", "", KindDurable)
+	require.NoError(t, err)
+	_, err = s.EvictByLabel("vacuum-test", false)
+	require.NoError(t, err)
+
+	err = s.Vacuum()
+	assert.NoError(t, err)
+}
+
+// --- DiskUsage ---
+
+func TestDiskUsage_ReturnsValidBreakdown(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Index("# Heading\n\nSome content here.", "du-test", "", KindDurable)
+	require.NoError(t, err)
+
+	breakdown, err := s.DiskUsage()
+	require.NoError(t, err)
+
+	assert.Greater(t, breakdown.DBFileSize, int64(0))
+	assert.Greater(t, breakdown.PageSize, int64(0))
+	assert.Greater(t, breakdown.TotalPages, int64(0))
+	assert.GreaterOrEqual(t, breakdown.FreelistPages, int64(0))
+
+	// Should have at least one kind entry.
+	assert.NotEmpty(t, breakdown.Kinds)
+	durableFound := false
+	for _, k := range breakdown.Kinds {
+		if k.Kind == "durable" {
+			durableFound = true
+			assert.Greater(t, k.Sources, int64(0))
+			assert.Greater(t, k.Chunks, int64(0))
+		}
+	}
+	assert.True(t, durableFound, "should have durable kind in breakdown")
+
+	// Top sources should include our test source.
+	assert.NotEmpty(t, breakdown.TopSources)
+	assert.Equal(t, "du-test", breakdown.TopSources[0].Label)
+}
+
+func TestDiskUsage_EmptyDB(t *testing.T) {
+	s := newTestStore(t)
+
+	// Force DB initialization without indexing.
+	_, err := s.getDB()
+	require.NoError(t, err)
+
+	breakdown, err := s.DiskUsage()
+	require.NoError(t, err)
+	assert.Greater(t, breakdown.PageSize, int64(0))
+	assert.Empty(t, breakdown.Kinds)
+	assert.Empty(t, breakdown.TopSources)
+}

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -158,13 +158,13 @@ func (s *ContentStore) Cleanup(dryRun bool, ephemeralTTL, sessionTTL time.Durati
 
 	merged := make([]SourceInfo, 0, len(oversized)+len(durable)+len(ephemeral)+len(session))
 	merged = append(merged, oversized...)
-	for _, src := range durable {
-		if !evictedIDs[src.ID] {
-			merged = append(merged, src)
+	for _, lists := range [][]SourceInfo{durable, ephemeral, session} {
+		for _, src := range lists {
+			if !evictedIDs[src.ID] {
+				merged = append(merged, src)
+			}
 		}
 	}
-	merged = append(merged, ephemeral...)
-	merged = append(merged, session...)
 
 	// Auto-vacuum when freelist exceeds 20% of total pages after a non-dry-run
 	// eviction. This reclaims dead pages left by deleted rows.

--- a/internal/store/cleanup.go
+++ b/internal/store/cleanup.go
@@ -121,17 +121,28 @@ func (s *ContentStore) ClassifySources(ephemeralTTL, sessionTTL time.Duration) (
 	return sources, nil
 }
 
-// Cleanup removes sources via three independent paths:
+// Cleanup removes sources via four independent paths:
+//   - oversized: sources whose total content exceeds maxSourceBytes (any kind).
 //   - durable: retention-score-based eviction (ADR-011) for `kind = 'durable'`.
 //   - ephemeral: strict TTL eviction for `kind = 'ephemeral'` (ADR-017).
 //   - session: strict TTL eviction for `kind = 'session'`.
 //
 // TTL-based eviction ignores access_count — search hits must not extend lifetime.
 // If dryRun is true, returns what would be removed without deleting.
-// The returned slice tags each SourceInfo with EvictionReason ("retention"
-// or "ttl") so callers can render per-kind breakdowns.
+// The returned slice tags each SourceInfo with EvictionReason ("retention",
+// "ttl", or "oversized") so callers can render per-kind breakdowns.
 // Vocabulary is shared and never deleted.
 func (s *ContentStore) Cleanup(dryRun bool, ephemeralTTL, sessionTTL time.Duration) ([]SourceInfo, error) {
+	oversized, err := s.cleanupOversized(dryRun)
+	if err != nil {
+		return nil, err
+	}
+	// Collect IDs already evicted so downstream passes don't re-process them.
+	evictedIDs := make(map[int64]bool, len(oversized))
+	for _, src := range oversized {
+		evictedIDs[src.ID] = true
+	}
+
 	durable, err := s.cleanupDurable(dryRun, ephemeralTTL, sessionTTL)
 	if err != nil {
 		return nil, err
@@ -145,10 +156,27 @@ func (s *ContentStore) Cleanup(dryRun bool, ephemeralTTL, sessionTTL time.Durati
 		return nil, err
 	}
 
-	merged := make([]SourceInfo, 0, len(durable)+len(ephemeral)+len(session))
-	merged = append(merged, durable...)
+	merged := make([]SourceInfo, 0, len(oversized)+len(durable)+len(ephemeral)+len(session))
+	merged = append(merged, oversized...)
+	for _, src := range durable {
+		if !evictedIDs[src.ID] {
+			merged = append(merged, src)
+		}
+	}
 	merged = append(merged, ephemeral...)
 	merged = append(merged, session...)
+
+	// Auto-vacuum when freelist exceeds 20% of total pages after a non-dry-run
+	// eviction. This reclaims dead pages left by deleted rows.
+	if !dryRun && len(merged) > 0 {
+		if ratio := s.FreelistRatio(); ratio > 0.20 {
+			slog.Info("auto-vacuum triggered", "freelist_ratio", fmt.Sprintf("%.1f%%", ratio*100))
+			if err := s.Vacuum(); err != nil {
+				slog.Warn("auto-vacuum failed", "error", err)
+			}
+		}
+	}
+
 	return merged, nil
 }
 
@@ -164,6 +192,52 @@ func (s *ContentStore) PurgeEphemeral(dryRun bool, ttl time.Duration) ([]SourceI
 // PurgeEphemeral for the session kind.
 func (s *ContentStore) PurgeSession(dryRun bool, ttl time.Duration) ([]SourceInfo, error) {
 	return s.cleanupByTTL(KindSession, dryRun, ttl)
+}
+
+// cleanupOversized finds and evicts sources whose total content size exceeds
+// the configured maxSourceBytes limit. These sources should never have been
+// indexed at the current limit — evicting is a correction, not a policy change.
+func (s *ContentStore) cleanupOversized(dryRun bool) ([]SourceInfo, error) {
+	db, err := s.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.Query(`
+		SELECT s.id, s.label, s.content_type, s.chunk_count, s.code_chunk_count,
+			s.indexed_at, s.last_accessed_at, s.access_count, s.content_hash, s.kind,
+			COALESCE(SUM(LENGTH(c.content)), 0) AS content_bytes
+		FROM sources s
+		LEFT JOIN chunks c ON CAST(c.source_id AS INTEGER) = s.id
+		GROUP BY s.id
+		HAVING content_bytes > ?
+		ORDER BY content_bytes DESC`, s.maxSourceBytes)
+	if err != nil {
+		return nil, fmt.Errorf("selecting oversized sources: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []SourceInfo
+	for rows.Next() {
+		var si SourceInfo
+		var indexedAt, lastAccessedAt string
+		var contentBytes int64
+		if err := rows.Scan(&si.ID, &si.Label, &si.ContentType, &si.ChunkCount,
+			&si.CodeChunkCount, &indexedAt, &lastAccessedAt, &si.AccessCount,
+			&si.ContentHash, &si.Kind, &contentBytes); err != nil {
+			slog.Warn("cleanupOversized: row scan failed, skipping", "error", err)
+			continue
+		}
+		si.IndexedAt, _ = time.Parse("2006-01-02 15:04:05", indexedAt)
+		si.LastAccessedAt, _ = time.Parse("2006-01-02 15:04:05", lastAccessedAt)
+		si.EvictionReason = "oversized"
+		candidates = append(candidates, si)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return candidates, s.evict(candidates, dryRun)
 }
 
 // cleanupDurable applies retention-score-based eviction to durable sources.
@@ -295,6 +369,37 @@ func (s *ContentStore) evict(candidates []SourceInfo, dryRun bool) error {
 		return fmt.Errorf("committing cleanup: %w", err)
 	}
 	return nil
+}
+
+// EvictByLabel force-evicts a source by its exact label, regardless of
+// retention score, TTL, or access count. Returns the evicted SourceInfo
+// or an error if the label is not found.
+func (s *ContentStore) EvictByLabel(label string, dryRun bool) (*SourceInfo, error) {
+	db, err := s.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	var si SourceInfo
+	var indexedAt, lastAccessedAt string
+	err = db.QueryRow(`
+		SELECT id, label, content_type, chunk_count, code_chunk_count,
+			indexed_at, last_accessed_at, access_count, content_hash, kind
+		FROM sources WHERE label = ?`, label).Scan(
+		&si.ID, &si.Label, &si.ContentType, &si.ChunkCount,
+		&si.CodeChunkCount, &indexedAt, &lastAccessedAt, &si.AccessCount,
+		&si.ContentHash, &si.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("source not found: %q", label)
+	}
+	si.IndexedAt, _ = time.Parse("2006-01-02 15:04:05", indexedAt)
+	si.LastAccessedAt, _ = time.Parse("2006-01-02 15:04:05", lastAccessedAt)
+	si.EvictionReason = "manual"
+
+	if err := s.evict([]SourceInfo{si}, dryRun); err != nil {
+		return nil, err
+	}
+	return &si, nil
 }
 
 // Stats returns knowledge base statistics. ephemeralTTL is required to

--- a/internal/store/diskusage.go
+++ b/internal/store/diskusage.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"fmt"
+	"os"
+)
+
+type TableSize struct {
+	Name  string
+	Pages int64
+	Bytes int64
+}
+
+type KindSize struct {
+	Kind         string
+	Sources      int64
+	Chunks       int64
+	ContentBytes int64
+}
+
+type TopSource struct {
+	Label        string
+	Kind         string
+	Chunks       int64
+	ContentBytes int64
+}
+
+type DiskUsageBreakdown struct {
+	DBFileSize    int64
+	PageSize      int64
+	TotalPages    int64
+	FreelistPages int64
+	VocabTerms    int64
+	Tables        []TableSize
+	Kinds         []KindSize
+	TopSources    []TopSource
+}
+
+func (s *ContentStore) DiskUsage() (*DiskUsageBreakdown, error) {
+	db, err := s.getDB()
+	if err != nil {
+		return nil, err
+	}
+
+	b := &DiskUsageBreakdown{}
+
+	if fi, err := os.Stat(s.dbPath); err == nil {
+		b.DBFileSize = fi.Size()
+	}
+
+	db.QueryRow("PRAGMA page_size").Scan(&b.PageSize)
+	db.QueryRow("PRAGMA page_count").Scan(&b.TotalPages)
+	db.QueryRow("PRAGMA freelist_count").Scan(&b.FreelistPages)
+	db.QueryRow("SELECT COUNT(*) FROM vocabulary").Scan(&b.VocabTerms)
+
+	rows, err := db.Query(`
+		SELECT name, SUM(pageno) as pages
+		FROM dbstat
+		GROUP BY name
+		ORDER BY pages DESC`)
+	if err != nil {
+		b.Tables = s.tableSizesFallback()
+	} else {
+		defer rows.Close()
+		for rows.Next() {
+			var t TableSize
+			if err := rows.Scan(&t.Name, &t.Pages); err != nil {
+				continue
+			}
+			t.Bytes = t.Pages * b.PageSize
+			b.Tables = append(b.Tables, t)
+		}
+	}
+
+	kindRows, err := db.Query(`
+		SELECT s.kind,
+			COUNT(DISTINCT s.id) as sources,
+			COUNT(c.rowid) as chunks,
+			COALESCE(SUM(LENGTH(c.content)), 0) as content_bytes
+		FROM sources s
+		LEFT JOIN chunks c ON CAST(c.source_id AS INTEGER) = s.id
+		GROUP BY s.kind
+		ORDER BY content_bytes DESC`)
+	if err != nil {
+		return b, fmt.Errorf("kind breakdown: %w", err)
+	}
+	defer kindRows.Close()
+	for kindRows.Next() {
+		var k KindSize
+		if err := kindRows.Scan(&k.Kind, &k.Sources, &k.Chunks, &k.ContentBytes); err != nil {
+			continue
+		}
+		b.Kinds = append(b.Kinds, k)
+	}
+
+	topRows, err := db.Query(`
+		SELECT s.label, s.kind,
+			COUNT(c.rowid) as chunks,
+			COALESCE(SUM(LENGTH(c.content)), 0) as bytes
+		FROM sources s
+		LEFT JOIN chunks c ON CAST(c.source_id AS INTEGER) = s.id
+		GROUP BY s.id
+		ORDER BY bytes DESC
+		LIMIT 15`)
+	if err != nil {
+		return b, fmt.Errorf("top sources: %w", err)
+	}
+	defer topRows.Close()
+	for topRows.Next() {
+		var t TopSource
+		if err := topRows.Scan(&t.Label, &t.Kind, &t.Chunks, &t.ContentBytes); err != nil {
+			continue
+		}
+		b.TopSources = append(b.TopSources, t)
+	}
+
+	return b, nil
+}
+
+func (s *ContentStore) tableSizesFallback() []TableSize {
+	db, _ := s.getDB()
+	var tables []TableSize
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type IN ('table', 'shadow') ORDER BY name")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		rows.Scan(&name)
+		var count int64
+		db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %q", name)).Scan(&count)
+		tables = append(tables, TableSize{Name: name, Pages: count})
+	}
+	return tables
+}

--- a/internal/store/diskusage.go
+++ b/internal/store/diskusage.go
@@ -6,9 +6,10 @@ import (
 )
 
 type TableSize struct {
-	Name  string
-	Pages int64
-	Bytes int64
+	Name     string
+	Pages    int64
+	Bytes    int64
+	RowCount int64 // populated by fallback when dbstat is unavailable
 }
 
 type KindSize struct {
@@ -32,6 +33,7 @@ type DiskUsageBreakdown struct {
 	FreelistPages int64
 	VocabTerms    int64
 	Tables        []TableSize
+	HasDBStat     bool // true when dbstat vtable is available (per-table page counts are accurate)
 	Kinds         []KindSize
 	TopSources    []TopSource
 }
@@ -54,13 +56,14 @@ func (s *ContentStore) DiskUsage() (*DiskUsageBreakdown, error) {
 	db.QueryRow("SELECT COUNT(*) FROM vocabulary").Scan(&b.VocabTerms)
 
 	rows, err := db.Query(`
-		SELECT name, SUM(pageno) as pages
+		SELECT name, COUNT(*) as pages
 		FROM dbstat
 		GROUP BY name
 		ORDER BY pages DESC`)
 	if err != nil {
 		b.Tables = s.tableSizesFallback()
 	} else {
+		b.HasDBStat = true
 		defer rows.Close()
 		for rows.Next() {
 			var t TableSize
@@ -130,7 +133,7 @@ func (s *ContentStore) tableSizesFallback() []TableSize {
 		rows.Scan(&name)
 		var count int64
 		db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %q", name)).Scan(&count)
-		tables = append(tables, TableSize{Name: name, Pages: count})
+		tables = append(tables, TableSize{Name: name, RowCount: count})
 	}
 	return tables
 }

--- a/internal/store/encryption_lifecycle_test.go
+++ b/internal/store/encryption_lifecycle_test.go
@@ -26,7 +26,7 @@ func TestEncryptionLifecycle(t *testing.T) {
 
 	// Phase 1: Create encrypted DB, index content, close.
 	t.Setenv(encryptionKeyEnv, key1)
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 
 	_, err := s.Index("# Encryption Test\n\nThe quick brown fox jumps over the lazy dog.", "lifecycle-doc", "", KindDurable)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestEncryptionLifecycle(t *testing.T) {
 
 	// Phase 2: Reopen with correct key, verify content is searchable.
 	t.Setenv(encryptionKeyEnv, key1)
-	s2 := NewContentStore(dbPath, dir, 0)
+	s2 := NewContentStore(dbPath, dir, 0, 0)
 	defer s2.Close()
 
 	results, err := s2.SearchWithFallback("quick brown fox", 5, SearchOptions{})
@@ -60,7 +60,7 @@ func TestEncryptionLifecycle(t *testing.T) {
 
 	// Phase 3: Wrong key fails cleanly.
 	t.Setenv(encryptionKeyEnv, wrongKey)
-	s3 := NewContentStore(dbPath, dir, 0)
+	s3 := NewContentStore(dbPath, dir, 0, 0)
 	_, err = s3.SearchWithFallback("anything", 5, SearchOptions{})
 	require.Error(t, err, "wrong key should produce an error")
 	assert.True(t, isWrongPassphrase(err), "error should be errWrongPassphrase, got: %v", err)
@@ -86,7 +86,7 @@ func TestEncryptionLifecycle(t *testing.T) {
 
 	// Phase 5: Old key fails on re-keyed DB.
 	t.Setenv(encryptionKeyEnv, key1)
-	s4 := NewContentStore(dbPath, dir, 0)
+	s4 := NewContentStore(dbPath, dir, 0, 0)
 	_, err = s4.SearchWithFallback("anything", 5, SearchOptions{})
 	require.Error(t, err, "old key should fail after re-key")
 	assert.True(t, isWrongPassphrase(err), "error should be errWrongPassphrase, got: %v", err)
@@ -94,7 +94,7 @@ func TestEncryptionLifecycle(t *testing.T) {
 
 	// Phase 6: New key works, content survived re-key.
 	t.Setenv(encryptionKeyEnv, key2)
-	s5 := NewContentStore(dbPath, dir, 0)
+	s5 := NewContentStore(dbPath, dir, 0, 0)
 	defer s5.Close()
 
 	results, err = s5.SearchWithFallback("quick brown fox", 5, SearchOptions{})

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -140,7 +140,7 @@ func TestOpenDB_UnencryptedDB_ClearError(t *testing.T) {
 	db.Close()
 
 	t.Setenv(encryptionKeyEnv, "test-passphrase-at-least-32-characters!!")
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	defer s.Close()
 
 	_, err = s.SearchWithFallback("anything", 5, SearchOptions{})

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -11,6 +11,19 @@ import (
 	"github.com/serpro69/capy/internal/sanitize"
 )
 
+const DefaultMaxSourceBytes = 2 * 1024 * 1024
+
+// SourceTooLargeError is returned when content exceeds the configured
+// MaxSourceBytes limit. Callers can use errors.As to extract the details.
+type SourceTooLargeError struct {
+	Size  int
+	Limit int
+}
+
+func (e *SourceTooLargeError) Error() string {
+	return fmt.Sprintf("source too large: %d bytes exceeds %d byte limit (configure store.max_source_bytes to adjust)", e.Size, e.Limit)
+}
+
 // Index indexes content into the knowledge base. It auto-detects
 // content type if contentType is empty. Duplicate content (same label
 // and hash) is skipped; changed content replaces the old source.
@@ -18,6 +31,10 @@ import (
 func (s *ContentStore) Index(content, label, contentType string, kind SourceKind) (*IndexResult, error) {
 	if !kind.Valid() {
 		return nil, fmt.Errorf("invalid source kind %q", kind)
+	}
+
+	if len(content) > s.maxSourceBytes {
+		return nil, &SourceTooLargeError{Size: len(content), Limit: s.maxSourceBytes}
 	}
 
 	if contentType == "" {
@@ -40,6 +57,10 @@ func (s *ContentStore) Index(content, label, contentType string, kind SourceKind
 func (s *ContentStore) IndexChunked(transcript, label, contentType string, kind SourceKind, chunks []Chunk) (*IndexResult, error) {
 	if !kind.Valid() {
 		return nil, fmt.Errorf("invalid source kind %q", kind)
+	}
+
+	if len(transcript) > s.maxSourceBytes {
+		return nil, &SourceTooLargeError{Size: len(transcript), Limit: s.maxSourceBytes}
 	}
 
 	transcript = sanitize.StripSecrets(transcript)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,9 +23,10 @@ func (s *ContentStore) ctx() context.Context {
 
 // ContentStore manages the FTS5 knowledge base.
 type ContentStore struct {
-	dbPath      string
-	projectDir  string
-	titleWeight float64
+	dbPath         string
+	projectDir     string
+	titleWeight    float64
+	maxSourceBytes int
 
 	mu sync.Mutex
 	db *sql.DB
@@ -63,15 +64,21 @@ type ContentStore struct {
 // NewContentStore creates a new ContentStore. The database is not opened
 // until the first operation (lazy initialization via getDB).
 // titleWeight controls the BM25 title column weight; values <= 0 default to 2.0.
-func NewContentStore(dbPath, projectDir string, titleWeight float64) *ContentStore {
+// maxSourceBytes caps the total content size accepted by Index/IndexChunked;
+// values <= 0 default to DefaultMaxSourceBytes.
+func NewContentStore(dbPath, projectDir string, titleWeight float64, maxSourceBytes int) *ContentStore {
 	if titleWeight <= 0 {
 		titleWeight = 2.0
 	}
+	if maxSourceBytes <= 0 {
+		maxSourceBytes = DefaultMaxSourceBytes
+	}
 	return &ContentStore{
-		dbPath:      dbPath,
-		projectDir:  projectDir,
-		titleWeight: titleWeight,
-		fuzzyCache:  make(map[string]*string),
+		dbPath:         dbPath,
+		projectDir:     projectDir,
+		titleWeight:    titleWeight,
+		maxSourceBytes: maxSourceBytes,
+		fuzzyCache:     make(map[string]*string),
 	}
 }
 
@@ -364,6 +371,44 @@ func (s *ContentStore) optimizeFTS(db *sql.DB) {
 	if _, err := db.Exec("INSERT INTO chunks_trigram(chunks_trigram) VALUES ('optimize')"); err != nil {
 		slog.Warn("FTS5 optimize failed for chunks_trigram", "error", err)
 	}
+}
+
+// Vacuum runs VACUUM to reclaim dead pages from the database file. Opens a
+// dedicated single connection (not the pool) since VACUUM rewrites the entire
+// file — with SQLCipher this also re-encrypts, so it's heavier than plain SQLite.
+func (s *ContentStore) Vacuum() error {
+	key, err := RequireEncryptionKey()
+	if err != nil {
+		return err
+	}
+	dsn := EncryptedDSN(s.dbPath, key) + "&_journal_mode=WAL&_busy_timeout=10000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return fmt.Errorf("opening database for vacuum: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("vacuum failed: %w", err)
+	}
+	return nil
+}
+
+// FreelistRatio returns the ratio of freelist pages to total pages.
+// Returns 0 if total pages is 0 or on any error.
+func (s *ContentStore) FreelistRatio() float64 {
+	db, err := s.getDB()
+	if err != nil {
+		return 0
+	}
+	var freelist, total int64
+	db.QueryRow("PRAGMA freelist_count").Scan(&freelist)
+	db.QueryRow("PRAGMA page_count").Scan(&total)
+	if total == 0 {
+		return 0
+	}
+	return float64(freelist) / float64(total)
 }
 
 // Checkpoint flushes the WAL into the main database file using a dedicated

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -19,7 +19,7 @@ func newTestStore(t *testing.T) *ContentStore {
 	t.Setenv(encryptionKeyEnv, testEncryptionKey)
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	t.Cleanup(func() { s.Close() })
 	return s
 }
@@ -31,7 +31,7 @@ func TestSchemaIdempotency(t *testing.T) {
 
 	// Open, init, close, repeat.
 	for range 2 {
-		s := NewContentStore(dbPath, dir, 0)
+		s := NewContentStore(dbPath, dir, 0, 0)
 		_, err := s.getDB()
 		require.NoError(t, err)
 		require.NoError(t, s.Close())
@@ -42,7 +42,7 @@ func TestDBDirectoryCreated(t *testing.T) {
 	t.Setenv(encryptionKeyEnv, testEncryptionKey)
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "sub", "deep", "test.db")
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	defer s.Close()
 
 	_, err := s.getDB()
@@ -59,7 +59,7 @@ func TestCloseCheckpointsWAL(t *testing.T) {
 	dbPath := filepath.Join(dir, "test.db")
 
 	// Index content to generate WAL data.
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	_, err := s.Index("# Test\n\nSome content to index.", "wal-test", "", KindDurable)
 	require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestCloseCheckpointsWAL(t *testing.T) {
 	}
 
 	// Data must survive — reopen and verify.
-	s2 := NewContentStore(dbPath, dir, 0)
+	s2 := NewContentStore(dbPath, dir, 0, 0)
 	defer s2.Close()
 	sources, err := s2.ListSources()
 	require.NoError(t, err)
@@ -90,14 +90,14 @@ func TestCheckpointMethod(t *testing.T) {
 	dbPath := filepath.Join(dir, "test.db")
 
 	// Index content, then close WITHOUT checkpoint (simulate unclean shutdown).
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	_, err := s.Index("# Checkpoint Test\n\nData that must survive.", "cp-test", "", KindDurable)
 	require.NoError(t, err)
 	// Close normally (which checkpoints), then write more via raw SQL to leave WAL dirty.
 	require.NoError(t, s.Close())
 
 	// Reopen, write, close the raw db handle without checkpoint.
-	s2 := NewContentStore(dbPath, dir, 0)
+	s2 := NewContentStore(dbPath, dir, 0, 0)
 	_, err = s2.Index("# More data\n\nAnother chunk.", "cp-test-2", "", KindDurable)
 	require.NoError(t, err)
 	// Access internal db directly to close without our checkpoint logic.
@@ -106,7 +106,7 @@ func TestCheckpointMethod(t *testing.T) {
 	s2.db = nil
 
 	// WAL may have data now. Run Checkpoint() from a fresh store.
-	s3 := NewContentStore(dbPath, dir, 0)
+	s3 := NewContentStore(dbPath, dir, 0, 0)
 	require.NoError(t, s3.Checkpoint())
 
 	// WAL must be gone or empty.
@@ -524,7 +524,7 @@ func TestCorruptDBRecovery(t *testing.T) {
 	// Write garbage to simulate corruption.
 	require.NoError(t, os.WriteFile(dbPath, []byte("this is not a database"), 0o644))
 
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	defer s.Close()
 
 	// Should recover: back up corrupt file and create a working DB.
@@ -556,7 +556,7 @@ func TestCorruptDBRecoveryPreservesBackup(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(dbPath, garbage, 0o644))
 
-	s := NewContentStore(dbPath, dir, 0)
+	s := NewContentStore(dbPath, dir, 0, 0)
 	defer s.Close()
 
 	_, err := s.getDB()
@@ -580,7 +580,7 @@ func TestNonCorruptionErrorDoesNotTriggerRecovery(t *testing.T) {
 	t.Setenv(encryptionKeyEnv, testEncryptionKey)
 	// Point at a non-existent nested directory — this is a "creating DB directory"
 	// error, not corruption. Should not attempt recovery.
-	s := NewContentStore("/dev/null/impossible/path/test.db", "", 0)
+	s := NewContentStore("/dev/null/impossible/path/test.db", "", 0, 0)
 	_, err := s.getDB()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating DB directory")


### PR DESCRIPTION
- (fix) Add source-size guard to prevent knowledge.db bloat (#43)
  Store-level MaxSourceBytes gate (2 MB default) on Index/IndexChunked
  rejects oversized content before chunking. Cleanup retroactively evicts
  existing oversized sources. New cleanup --source flag for manual eviction,
  auto-VACUUM when freelist > 20%, and capy dbsize diagnostic subcommand.
- (chore) Update knowledge.db

## Test Plan
```bash
go build -tags fts5 ./cmd/capy/

./capy dbsize --project-dir .

./capy cleanup --project-dir .

./capy cleanup --force --project-dir .

./capy dbsize --project-dir .


./capy cleanup --source "issue-41-gist" --project-dir .

./capy cleanup --source "issue-41-gist" --force --project-dir .


./capy cleanup --vacuum --project-dir .

```