### PR TITLE
Update capy to use fetch ephemeral default and routing rewrite

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -1,8 +1,31 @@
-# capy — MANDATORY routing rules
+# capy — context-window routing
 
-You have capy MCP tools available. These rules are NOT optional — they protect your context window from flooding. A single unrouted command can dump 56 KB into context and waste the entire session.
+Capy MCP tools protect your context window by keeping raw tool output in sandboxed subprocesses and indexing it for on-demand search.
 
-## BLOCKED commands — do NOT attempt these
+## Decision principle
+
+Choose the tool based on what you need from the output:
+
+- **Comprehension** (understand the full content) → direct tools (Bash, Read)
+- **Extraction** (specific facts from large output) → capy tools
+
+## When to use direct tools (Bash / Read)
+
+- **Git commands:** diffs, logs, status, branch — always Bash. Diffs are comprehension content; BM25 fragments destroy review quality.
+- **Small-output commands (<~50 lines):** ls, wc, file, git status — Bash directly. Sandbox overhead exceeds savings.
+- **Files to comprehend or edit:** Read tool. Required before Edit.
+- **Sequential/ordered content:** test output, build logs where order matters — Bash or Read.
+- **Instruction files, checklists, configs:** Read and internalize whole. BM25 returns ranked fragments, destroying structural relationships.
+
+## When to use capy tools
+
+- **`capy_batch_execute`:** Broad exploration — multiple commands + queries in one call. Example: initial repo scan with `rg --files` + symbol searches.
+- **`capy_execute` / `capy_execute_file`:** Single command or file producing hundreds+ lines where you only need extracted facts. API calls, log analysis, data processing.
+- **`capy_fetch_and_index`:** Fetch web content. Default ephemeral (24h TTL, excluded from default search). Pass `kind: "durable"` for reference docs. Use `source: "<label>"` for follow-up search.
+- **`capy_index`:** Persist curated knowledge durably. Content you explicitly want searchable across sessions.
+- **`capy_search`:** Query indexed content. Batch all questions as array. Default excludes ephemeral — use `include_kinds` or `source:` to include.
+
+## Blocked commands — enforced by hooks
 
 ### curl / wget — BLOCKED
 Any Bash command containing `curl` or `wget` is intercepted and replaced with an error message. Do NOT retry.
@@ -20,15 +43,23 @@ WebFetch calls are denied entirely. The URL is extracted and you are told to use
 Instead use:
 - `capy_fetch_and_index(url, source)` then `capy_search(queries)` to query the indexed content
 
-## REDIRECTED tools — use sandbox equivalents
+## Source kinds
 
-### Bash (>20 lines output)
-Bash is ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`, and other short-output commands.
-For everything else, use:
-- `capy_batch_execute(commands, queries)` — run multiple commands + search in ONE call
-- `capy_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
+Every indexed entry has a **kind** that controls its lifecycle and search visibility:
 
-### Read vs capy_execute_file / capy_index
+| Kind | What produces it | Retention | Included by default in search? |
+|------|-----------------|-----------|-------------------------------|
+| `durable` | `capy_index`, `capy_fetch_and_index(kind: "durable")` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
+| `ephemeral` | `capy_execute`, `capy_execute_file`, `capy_batch_execute`, `capy_fetch_and_index` (default) | Strict TTL — swept after expiry | No |
+| `session` | `capy sweep` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+
+**Querying non-default kinds:** pass `include_kinds` to `capy_search`:
+- `include_kinds: ["durable", "ephemeral"]` — recover output from earlier commands in this session
+- `include_kinds: ["durable", "session"]` — search past conversation transcripts
+- `include_kinds: ["durable", "ephemeral", "session"]` — search everything
+- Or use `source: "<label>"` to bypass kind filtering entirely (matches any kind)
+
+## Read vs capy_execute_file
 
 **Default to `Read`.** It's cheap for normal-sized files, shows you actual content (not just patterns you knew to grep for), and is required if an Edit follows. Use `offset`/`limit` to scope large files.
 
@@ -46,42 +77,15 @@ For everything else, use:
 
 **Rule of thumb:** capy saves context only when raw data would otherwise flood context and you don't need the full content. If the document is meant to be followed as instructions, applied as a checklist, or read for comprehension — use `Read`. Indexing turns a coherent document into a bag of fragments.
 
-### Grep (large results)
-Grep results can flood context. Use `capy_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.
-
-## Tool selection hierarchy
-
-1. **GATHER**: `capy_batch_execute(commands, queries)` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls.
-2. **FOLLOW-UP**: `capy_search(queries: ["q1", "q2", ...])` — Query indexed content. Pass ALL questions as array in ONE call.
-3. **PROCESSING**: `capy_execute(language, code)` | `capy_execute_file(path, language, code)` — Sandbox execution. Only stdout enters context.
-4. **WEB**: `capy_fetch_and_index(url, source)` then `capy_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
-5. **INDEX**: `capy_index(content, source)` — Store content in FTS5 knowledge base for later search.
-
-## Source kinds
-
-Every indexed entry has a **kind** that controls its lifecycle and search visibility:
-
-| Kind | What produces it | Retention | Included by default in search? |
-|------|-----------------|-----------|-------------------------------|
-| `durable` | `capy_index`, `capy_fetch_and_index` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
-| `ephemeral` | `capy_execute`, `capy_execute_file`, `capy_batch_execute` (auto-indexed output) | Strict TTL — swept after expiry | No |
-| `session` | `capy sweep` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
-
-**Querying non-default kinds:** pass `include_kinds` to `capy_search`:
-- `include_kinds: ["durable", "ephemeral"]` — recover output from earlier commands in this session
-- `include_kinds: ["durable", "session"]` — search past conversation transcripts
-- `include_kinds: ["durable", "ephemeral", "session"]` — search everything
-- Or use `source: "<label>"` to bypass kind filtering entirely (matches any kind)
-
-## Subagent routing
-
-When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.
-
 ## Output constraints
 
 - Keep responses under 500 words.
 - Write artifacts (code, configs, PRDs) to FILES — never return them as inline text. Return only: file path + 1-line description.
 - When indexing content, use descriptive source labels so others can `capy_search(source: "label")` later.
+
+## Subagent routing
+
+When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.
 
 ## capy commands
 

--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -51,11 +51,10 @@ Every indexed entry has a **kind** that controls its lifecycle and search visibi
 |------|-----------------|-----------|-------------------------------|
 | `durable` | `capy_index`, `capy_fetch_and_index(kind: "durable")` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
 | `ephemeral` | `capy_execute`, `capy_execute_file`, `capy_batch_execute`, `capy_fetch_and_index` (default) | Strict TTL — swept after expiry | No |
-| `session` | `capy sweep` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+| `session` | `capy sweep` (indexes past conversation transcripts) | Strict TTL — swept after expiry | Yes |
 
 **Querying non-default kinds:** pass `include_kinds` to `capy_search`:
 - `include_kinds: ["durable", "ephemeral"]` — recover output from earlier commands in this session
-- `include_kinds: ["durable", "session"]` — search past conversation transcripts
 - `include_kinds: ["durable", "ephemeral", "session"]` — search everything
 - Or use `source: "<label>"` to bypass kind filtering entirely (matches any kind)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,6 @@ It's a port of `context-mode` project written in Go, aiming to utilize Go's feat
 
 @.claude/CLAUDE.extra.md
 
-# capy — MANDATORY routing rules
+# capy — context-window routing
 
 @.capy/AGENTS.md

--- a/docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md
+++ b/docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md
@@ -44,11 +44,15 @@ The implicit promote/demote path already exists in `indexPreparedChunks`: re-ind
 
 ### D3: Search fallback listing capped to summary-only
 
-Replace the unbounded per-source listing in the search handler's no-results path with a single summary line: source count and total section count. Per-query "ephemeral excluded" and "session excluded" hints are preserved — they provide targeted, actionable guidance. Detailed source browsing belongs in `capy_stats`, not in search fallback output.
+Replace the unbounded per-source listing in the search handler's no-results path with a single summary line: source count per included kind. Section counts are intentionally omitted — source count is sufficient for a directional "content exists, refine your query" signal, and `capy_stats` provides the detailed breakdown. Per-query "ephemeral excluded" and "session excluded" hints are preserved — they provide targeted, actionable guidance.
 
-### D4: Full AGENTS.md rewrite — task-aware routing
+### D4: Full routing rewrite — AGENTS.md, generated routing block, and runtime hook
 
-Replace the current "capy is the primary tool, use Bash only for exceptions" framing with a task-aware decision tree:
+Replace the current "capy is the primary tool, use Bash only for exceptions" framing with a task-aware decision tree across all three routing surfaces:
+
+1. **`.capy/AGENTS.md`** — the static file agents read from the repo.
+2. **`internal/platform/routing.go` — `GenerateRoutingInstructions()`** — the routing block written to CLAUDE.md/AGENTS.md during `capy setup`.
+3. **`internal/hook/routing.go` — `RoutingBlock()`** — the XML routing block injected at runtime into subagent prompts and session start. Plus the `BASH_GUIDANCE`, `GREP_GUIDANCE` constants.
 
 **Core principle:** Use capy when you need to *extract* specific facts from large output. Use direct tools (Bash, Read) when you need to *comprehend* content fully.
 
@@ -59,11 +63,16 @@ Key routing rules:
 - **Sequential/ordered content uses Read/Bash.** BM25 ranking reorders by relevance, destroying sequence.
 - **High-volume exploration and extraction uses capy.** Broad `rg` searches, API responses, large log analysis — content is large and you only need targeted facts.
 
-### D5: Tool description updates
+### D5: Fetch cache must respect kind changes
+
+The TTL cache check in `handleFetchAndIndex` (line 52-68) returns a cache hit before any kind handling runs. If a source was previously fetched as durable and is within the TTL window, a re-fetch with `kind: "ephemeral"` silently returns the old durable entry without re-indexing. Fix: parse/validate `kind` before the cache check; when the requested kind differs from `meta.Kind` (available on `SourceMeta`), bypass the cache and proceed with re-fetch+re-index.
+
+### D6: Tool description updates
 
 - `capy_execute`: Remove "MANDATORY" prefix and "git queries (git log, git diff)" from examples.
 - `capy_batch_execute`: Remove "THIS IS THE PRIMARY TOOL." Reframe as exploration/extraction tool.
 - `capy_fetch_and_index`: Document ephemeral default and `kind` parameter. Note that follow-up search needs `source:` filter or `include_kinds`.
+- `capy_search`: Fix stale description. Main description says "returns only durable sources (fetched/indexed reference content)" — change to "returns durable and session sources" and remove the parenthetical about fetched content. Fix `include_kinds` description: change default from `[\"durable\"] only` to `[\"durable\", \"session\"]` to match actual `effectiveKindFilter` behavior. Update `"durable"` parenthetical from "fetched/indexed reference content" to "explicitly indexed reference content".
 
 ## Variants Considered
 

--- a/docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md
+++ b/docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md
@@ -1,0 +1,127 @@
+# ADR-023: Fetch ephemeral-by-default and task-aware routing rewrite
+
+**Status:** Accepted
+**Date:** 2026-05-11
+**Supersedes:** Amends ADR-017 (fetch_and_index kind assignment).
+
+## Context
+
+Issue [#44](https://github.com/serpro69/capy/issues/44) identified two related problems from production session transcript analysis (Codex and Claude Code):
+
+### Problem A: Over-preservation of task artifacts
+
+`capy_fetch_and_index` hardcodes `KindDurable` (ADR-017 §Write sites table). Every fetched URL — GitHub issues, PR pages, investigation logs, gists — becomes a permanent DB resident subject to retention-score cleanup rather than TTL eviction. This causes:
+
+- Knowledge DB bloat from transient task context (the same class of problem ADR-022 addressed for oversized sources).
+- BM25 pollution: a fetched GitHub issue discussing "authentication" competes head-to-head with a curated API reference doc mentioning "authentication." The issue is noise; the reference doc is signal.
+
+Evidence: session transcripts show `capy_fetch_and_index` used on GitHub issues during investigation, producing durable rows that outlive the task by weeks.
+
+### Problem B: Over-routing through capy
+
+AGENTS.md (the agent-facing routing rules) and MCP tool descriptions push agents toward capy for *all* commands, including operations where BM25 fragmentation actively degrades output quality:
+
+- **Diffs routed through `capy_batch_execute`:** A code review session ran `git diff master...HEAD` (128.8KB) through batch execute, chunked it into 16 BM25-indexed sections, then queried fragments. Code review requires full sequential comprehension of every changed line — BM25 keyword search returns ranked fragments, missing cross-chunk interactions, boundary-spanning bugs, and structural context.
+- **Small commands routed through sandbox:** `git status --short`, `wc -l`, `git branch --show-current` (1-25 lines of output) routed through `capy_batch_execute`. The sandbox + indexing + BM25 query overhead exceeds any context savings on sub-50-line output.
+- **Unbounded source listings:** The search handler's no-results fallback dumps every indexed source label — itself context pollution from capy's own control plane.
+
+Root cause in AGENTS.md: "Bash is ONLY for: git, mkdir, rm, mv..." (too restrictive) and `capy_batch_execute` tool description: "THIS IS THE PRIMARY TOOL" (unconditional primacy). These create a gravity well where agents default to capy for everything because the instructions say to.
+
+## Decision
+
+### D1: `capy_fetch_and_index` defaults to `KindEphemeral`
+
+Add an optional `kind` parameter to `capy_fetch_and_index` accepting `"durable"` or `"ephemeral"`, defaulting to `"ephemeral"`.
+
+- Ephemeral fetched content is subject to TTL eviction (24h default, per ADR-017) and excluded from default search.
+- Agents opt into `kind: "durable"` for content intended as persistent reference (API docs, library guides, specifications).
+- The fetch response already guides agents to use `source: "<label>"` for follow-up queries, which bypasses kind filtering — the fetch-then-search workflow works without change.
+- `capy_index` remains hardcoded `KindDurable`. Explicit indexing represents deliberate intent to persist; adding a kind parameter would muddy that signal.
+
+### D2: No `capy_promote` tool
+
+The implicit promote/demote path already exists in `indexPreparedChunks`: re-indexing content with the same label and hash but a different kind updates the kind in-place. A dedicated tool adds API surface without clear value — agents that need to promote ephemeral content can re-index via `capy_index(content, source)`.
+
+### D3: Search fallback listing capped to summary-only
+
+Replace the unbounded per-source listing in the search handler's no-results path with a single summary line: source count and total section count. Per-query "ephemeral excluded" and "session excluded" hints are preserved — they provide targeted, actionable guidance. Detailed source browsing belongs in `capy_stats`, not in search fallback output.
+
+### D4: Full AGENTS.md rewrite — task-aware routing
+
+Replace the current "capy is the primary tool, use Bash only for exceptions" framing with a task-aware decision tree:
+
+**Core principle:** Use capy when you need to *extract* specific facts from large output. Use direct tools (Bash, Read) when you need to *comprehend* content fully.
+
+Key routing rules:
+- **Git commands always use Bash directly.** Diffs, logs, status — these are comprehension content or small output. Removing `git log, git diff` from `capy_execute` examples.
+- **Small-output commands (<~50 lines) use Bash directly.** Sandbox + index overhead exceeds savings.
+- **Content requiring full comprehension uses Read/Bash.** Code review diffs, files to edit, instruction documents, checklists.
+- **Sequential/ordered content uses Read/Bash.** BM25 ranking reorders by relevance, destroying sequence.
+- **High-volume exploration and extraction uses capy.** Broad `rg` searches, API responses, large log analysis — content is large and you only need targeted facts.
+
+### D5: Tool description updates
+
+- `capy_execute`: Remove "MANDATORY" prefix and "git queries (git log, git diff)" from examples.
+- `capy_batch_execute`: Remove "THIS IS THE PRIMARY TOOL." Reframe as exploration/extraction tool.
+- `capy_fetch_and_index`: Document ephemeral default and `kind` parameter. Note that follow-up search needs `source:` filter or `include_kinds`.
+
+## Variants Considered
+
+### URL-heuristic default kind for fetch
+
+Infer kind from URL pattern: `github.com` issues/PRs/gists → ephemeral; docs/reference URLs → durable; unknown → ephemeral.
+
+**Dropped.** URL patterns are fragile (is `github.com/org/repo/wiki` a reference or an investigation artifact?), the heuristic would need ongoing maintenance, and it obscures intent. An explicit `kind` parameter is clearer — the agent decides, not a regex.
+
+### Targeted patches to AGENTS.md instead of full rewrite
+
+Keep the current structure but add anti-patterns and soften language.
+
+**Dropped.** The current structure's "ONLY for" / "PRIMARY TOOL" framing creates a bias that patches cannot overcome. Agents weight strong imperative language heavily. Adding "except for diffs" caveats to a document that says "MANDATORY: Use for any command" sends contradictory signals. A clean rewrite with a coherent principle (comprehension vs. extraction) is more reliable than patching exceptions onto a flawed frame.
+
+### Include ephemeral in default search
+
+Change `effectiveKindFilter` default from `{durable, session}` to `{durable, ephemeral, session}` so freshly fetched content appears in default search.
+
+**Dropped.** ADR-017 specifically excluded ephemeral from default search to prevent BM25 pollution from command output. Fetch content becoming ephemeral doesn't change the rationale — transient content should not dilute curated knowledge in search results. The `source:` filter bypass is the correct access pattern for fetch-then-search.
+
+### Separate AGENTS.md per AI runtime
+
+Create runtime-specific routing guidance for Claude Code vs. Codex.
+
+**Dropped.** Both runtimes use the same MCP tool names and face the same routing tradeoffs. Separate docs would diverge and require double maintenance. A single document using plain language and MCP tool names is universally applicable.
+
+## Rationale
+
+- Ephemeral-default for fetch aligns with observed usage: the majority of fetched URLs are task-scoped investigation artifacts, not curated reference docs. Opting into durable is a low-friction escape hatch.
+- Task-aware routing preserves capy's value for its core use case (context reduction on genuinely large output) while preventing misuse that degrades output quality (BM25 fragmentation of comprehension content).
+- Summary-only search fallback eliminates a direct context pollution vector from capy's own control plane.
+- Pre-release status makes the behavioral changes (fetch default, tool descriptions) acceptable without deprecation cycles.
+
+## Consequences
+
+**Positive**
+
+- Fetched task artifacts no longer become permanent DB residents. Knowledge DB contains higher-signal content.
+- Code reviews receive full diffs in context instead of BM25 fragments — review quality improves.
+- Small commands execute directly without sandbox overhead — lower latency, no false context savings.
+- Search no-results responses are concise instead of flooding context with source inventories.
+
+**Negative / trade-offs**
+
+- **Breaking change:** existing workflows that fetch reference docs and expect them to persist across sessions must add `kind: "durable"`. Acceptable in pre-release.
+- **Fetch-then-search requires `source:` filter:** agents must pass `source: "<label>"` or `include_kinds: ["durable", "ephemeral"]` to query freshly fetched ephemeral content. The fetch response text already guides this pattern.
+- **AGENTS.md rewrite risk:** agents may over-correct and stop using capy for legitimate high-volume extraction. Mitigated by positive guidance ("when to use capy") alongside negative guidance ("when not to").
+- **Tool description softening risk:** without "MANDATORY" and "PRIMARY TOOL," agents on some runtimes may underweight capy. Mitigated by clear positive framing of capy's value in extraction scenarios.
+
+**Cross-reference**
+
+- ADR-017 (source-kind separation) — this ADR amends the fetch write site's kind assignment from `durable` to `ephemeral` in ADR-017's write-site table. All other ADR-017 decisions (schema, cleanup split, search defaults) remain unchanged.
+- ADR-022 (source-size guard) — orthogonal. Size guards prevent oversized sources regardless of kind.
+- ADR-011 (conservative cleanup) — preserved for durable; ephemeral uses strict TTL per ADR-017.
+
+## Release notes
+
+- **Breaking change — `capy_fetch_and_index` default kind:** fetched web content is now indexed as `ephemeral` (24h TTL, excluded from default search). To persist reference docs across sessions, pass `kind: "durable"`. Follow-up searches on fetched content should use `source: "<label>"` to bypass kind filtering.
+- **Search improvement:** no-results fallback no longer dumps the full source inventory. Use `capy_stats` for source browsing.
+- **Tool routing guidance updated:** AGENTS.md and tool descriptions now use task-aware routing. Git commands, small-output commands, and comprehension content (diffs, files for review) use direct tools. Capy is recommended for high-volume exploration and extraction tasks.

--- a/docs/wip/issue-44-over-preservation-routing/.sessions/design-session.txt
+++ b/docs/wip/issue-44-over-preservation-routing/.sessions/design-session.txt
@@ -1,0 +1,726 @@
+ ▐▛███▜▌   Claude Code v2.1.138
+▝▜█████▛▘  Opus 4.6 · Claude Team
+  ▘▘ ▝▝    ~/Projects/personal/capy
+
+  Using Opus 4.6 (from .claude/settings.json) · /model to change
+
+❯ https://github.com/serpro69/capy/issues/44                                    
+  Analyze the issue, make sure you understand the root cause, and the fix path. 
+   Then do an analysis on the proposed fix: how will it affect existing users?  
+  does it reduce durable knowledge usability? does it increase or decrese value 
+   of capy? any other concerns? any other improvements?                         
+
+⏺ Let me fetch the issue and understand the codebase context.
+
+  Called capy 2 times (ctrl+o to expand)
+
+⏺ Good, I have the full issue. Now let me look at the current implementation to
+  understand the affected code paths.
+
+⏺ Explore(Explore fetch_and_index and kind handling)
+  ⎿  Done (13 tool uses · 40.4k tokens · 46s)
+  (ctrl+o to expand)
+
+⏺ Excellent. Now I have full context on the issue and the codebase. Here's my
+  analysis:
+
+  ---
+  Issue #44 — Root Cause
+
+  The core problem is a kind assignment mismatch: capy_fetch_and_index and
+  capy_index hardcode KindDurable with no override. This means every fetched
+  GitHub issue, PR page, log, or investigation artifact gets permanent retention
+   scoring — even though most of this content is session-scoped task context
+  that becomes worthless after the conversation ends.
+
+  The secondary problem is unbounded search fallback listings leaking capy's own
+   control-plane output into context, undermining the tool's purpose.
+
+  ---
+  Analysis of the Proposed Fix (7 suggestions)
+
+  1. "Make fetched web content ephemeral by default, add kind parameter"
+
+  Impact on existing users: This is a breaking behavioral change. Today, users
+  who capy_fetch_and_index reference docs (API docs, library guides) rely on
+  them persisting across sessions. Flipping default to ephemeral means those
+  docs vanish after 24h TTL.
+
+  My take: The suggestion is directionally right but the default is wrong. The
+  better fix: keep durable as default for capy_index (explicit user intent to
+  persist), but add a kind parameter to capy_fetch_and_index defaulting to
+  ephemeral. Rationale: fetching a URL is usually investigative; if you want it
+  durable, opt in. This is a defensible split — explicit indexing = durable
+  intent, fetching = transient by default.
+
+  2. "Add capy_promote(source) tool"
+
+  Good idea, low urgency. The implicit promote path already exists in
+  indexPreparedChunks (re-index with different kind). A dedicated tool would be
+  cleaner UX but the plumbing works today. Worth doing, not blocking.
+
+  3. "Hard-cap search fallback listings"
+
+  Unambiguously good. This is a context pollution bug, not a design question.
+  The source inventory listing should be capped with a summary count. No
+  tradeoffs.
+
+  4. "capy_fetch_preview / capy_fetch_context mode"
+
+  Redundant if #1 is done well. If capy_fetch_and_index accepts kind: 
+  "ephemeral", you don't need a separate tool. A separate tool adds API surface
+  without clear value.
+
+  5. "Tune tool descriptions"
+
+  Correct but already partially addressed. AGENTS.md already says "Read is
+  default, capy for large output." Could be stronger in the tool descriptions
+  themselves. Low effort, worth doing.
+
+  6. "Add bytes_processed / bytes_indexed stats"
+
+  Nice-to-have, orthogonal. Related to #43's source-size guards. Not part of the
+   core fix.
+
+  7. "Separate default lifetimes by source origin"
+
+  This is the real design insight and subsumes #1 and #4. Instead of a single
+  default, the kind should be determined by the source origin: command output →
+  ephemeral (already done), fetched pages → ephemeral (proposed), explicit
+  capy_index → durable (already done). This is the cleanest mental model.
+
+  ---
+  Does this reduce durable knowledge usability?
+
+  No, if done right. The key is that capy_index (explicit "remember this") stays
+   durable by default. capy_fetch_and_index gaining a kind parameter with
+  ephemeral default doesn't remove any capability — users who want durable
+  fetches pass kind: "durable". The implicit promote path means even ephemeral
+  content can be promoted later.
+
+  The risk is agent prompt drift: if AGENTS.md and tool descriptions aren't
+  updated together, agents might stop persisting docs they should. But that's a
+  documentation task, not a design flaw.
+
+  Does it increase or decrease capy's value?
+
+  Net increase. Capy's pitch is "only valuable knowledge persists." Today it
+  violates that by durably storing throwaway GitHub issues. Fixing this makes
+  the knowledge DB higher-signal and reduces bloat (#43 follow-on). The
+  retention scoring system works better when it's not diluted with task
+  artifacts.
+
+  Other concerns
+
+  1. Migration: Existing knowledge DBs have durable rows that should be
+  ephemeral. A one-time cleanup or re-scoring pass might be warranted, but not
+  strictly necessary — retention scoring will eventually demote cold durable
+  entries.
+  2. The search default includes session but excludes ephemeral
+  (effectiveKindFilter returns {durable, session}). If fetched content becomes
+  ephemeral, it won't appear in default searches. This needs attention — either
+  the default should include ephemeral, or there should be a "recent" scope that
+   includes it. Otherwise, fetching a page and immediately searching it won't
+  work without explicit include_kinds.
+  3. The fallback listing cap (#3) should be done first — it's a bug, not a
+  design choice, and it's the quickest win.
+
+✻ Worked for 1m 41s
+
+❯ agree on all counts                                                           
+  have you also looked at the linked gist that contains 2 exported sessions?    
+  when you look at the AI behavior , will your above suggestions fix that?      
+  E.g., AI is doing review-code, and then runs diffs via capy abstraction, then 
+   queries those via capy, instead of just "git diff". The same for finding     
+  files, grep/rg , and so on. It seems that in those cases at the very least    
+  capy adds noise, and at worse it makes it harder to find relevant content or  
+  it gets lost completely                                                       
+  is that a valid concern, are we addressing it?                                
+
+⏺ Let me find and analyze the gist with the exported sessions.
+
+  Called capy 2 times (ctrl+o to expand)
+
+⏺ The gist is large (109KB). Let me search for the specific anti-patterns the
+  user described.
+
+  Called capy 3 times (ctrl+o to expand)
+
+⏺ Let me get the raw gist files directly — the HTML rendering is losing the
+  actual session content.
+
+  Called capy (ctrl+o to expand)
+
+⏺ Now I have a clear picture. Let me also check AGENTS.md to see the current
+  routing instructions that are driving this behavior.
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Now I have the full picture. Here's my analysis:
+
+  ---
+  The Gist Sessions Reveal a Deeper Problem
+
+  Your concern is valid and it's not fully addressed by the 7 suggestions in the
+   issue. The sessions show two distinct anti-patterns:
+
+  Anti-pattern 1: "Capy as universal router"
+
+  The review-code session routes git diff master...HEAD through
+  capy_batch_execute, producing 128.8KB of raw diff that gets chunked into 16
+  sections, then immediately queried with BM25 search. Then it does it again —
+  reading every changed file through a second capy_batch_execute call (169.7KB,
+  74 sections), then querying those fragments via capy_search.
+
+  The problem: For code review, the AI needs to comprehend the full diff — every
+   line, in order, with surrounding context. BM25 search returns ranked
+  fragments. You literally cannot do a proper code review by keyword-searching
+  fragments of a diff. You'll miss subtle bugs that span chunk boundaries, miss
+  context that wasn't in the top-N results, and miss interactions between
+  changes in different files.
+
+  This is the same anti-pattern AGENTS.md already calls out for instruction
+  files ("indexing turns a coherent document into a bag of fragments") — but it
+  applies equally to diffs, and AGENTS.md doesn't say that.
+
+  Anti-pattern 2: "Capy for known-small output"
+
+  git status --short, wc -l, git branch --show-current — all routed through
+  capy_batch_execute. These produce 1-25 lines. The overhead of sandbox +
+  indexing + BM25 query is pure waste. The AI sees the AGENTS.md line "Bash is
+  ONLY for: git, mkdir, rm, mv..." but the capy_batch_execute description says
+  "THIS IS THE PRIMARY TOOL" — and the primacy instruction wins.
+
+  What the 7 suggestions fix vs. what they don't
+
+  Problem: Durable-by-default for fetched pages
+  Fixed by suggestions?: Yes (#1, #7)
+  ────────────────────────────────────────
+  Problem: Unbounded fallback listings
+  Fixed by suggestions?: Yes (#3)
+  ────────────────────────────────────────
+  Problem: Tool description over-bias
+  Fixed by suggestions?: Partially (#5) — but the language is too vague
+  ────────────────────────────────────────
+  Problem: Diff-via-BM25 destroying review quality
+  Fixed by suggestions?: No
+  ────────────────────────────────────────
+  Problem: Small commands routed through sandbox
+  Fixed by suggestions?: No
+  ────────────────────────────────────────
+  Problem: Loss of sequential/structural information
+  Fixed by suggestions?: No
+
+  What's actually needed beyond the 7 suggestions
+
+  The root cause is in AGENTS.md lines 25-29 and the tool hierarchy on lines 
+  53-58. The "Bash is ONLY for" allowlist is too restrictive, and the hierarchy
+  positions capy_batch_execute as "Primary tool" unconditionally. This creates a
+   gravity well — agents default to capy for everything because the instructions
+   say to.
+
+  The fix needs to be in AGENTS.md itself — a task-awareness heuristic:
+
+  1. Diffs and structured sequential content should never go through capy. git 
+  diff, git log, file reads for review — these require full sequential
+  comprehension, not BM25 fragments. Add this as an explicit anti-pattern
+  alongside the existing ones.
+  2. The "Bash is ONLY for" allowlist needs to become a "Bash is fine for" 
+  guideline with a size threshold, not a hard block. Something like: "Bash is
+  appropriate for commands that produce <~50 lines. For commands that produce
+  hundreds or thousands of lines of raw output that you only need to search, use
+   capy."
+  3. The tool hierarchy needs a preamble: "Choose the tool based on what you
+  need from the output — full comprehension vs. targeted extraction. Capy is for
+   targeted extraction from large output. Direct tools (Bash, Read) are for
+  content you need to understand fully."
+  4. Code review specifically should be called out: when doing review-code, the
+  diff is the thing being reviewed — it must enter context whole (or in
+  file-sized chunks via Read), not be fragmented through BM25.
+
+  Does this decrease capy's value?
+
+  No — it increases it by preventing misuse that makes capy look bad. Right now,
+   when an AI uses capy for a diff review and produces a mediocre review because
+   it only saw BM25 fragments, that's capy making the output worse. Correct
+  routing means capy is only used where it genuinely helps, which makes the
+  context savings real instead of illusory.
+
+  Bottom line
+
+  The 7 suggestions are valid and should be implemented, but they address the
+  storage/retention side of the problem. The gist sessions expose a
+  routing/comprehension problem that lives in AGENTS.md's tool selection rules.
+  Both need to be fixed together, or agents will keep routing diffs and small
+  commands through capy even after the kind/retention changes land.
+
+✻ Cogitated for 1m 17s
+
+❯ This seems like a feature design, rather than a quick fix? Should we use      
+  kk:design?                                                                    
+
+⏺ Yes, absolutely. This touches routing rules, tool behavior, storage semantics,
+   and agent-facing documentation — that's a design problem, not a patch. Let me
+   kick it off.
+
+⏺ Skill(kk:design)
+  ⎿  Successfully loaded skill
+
+⏺ Starting the design skill. First, loading all instruction files before
+  engaging with the content.
+
+  Read 3 files (ctrl+o to expand)
+
+⏺ Good. Now running profile detection — keyword scan against the idea prose.
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ The idea prose mentions Go files (tool_fetch.go, tool_index.go, etc.) and
+  Go-specific paths. The Go profile matches.
+
+⏺ User answered Claude's questions:
+  ⎿  · This involves Go source changes (tool_fetch.go, tool_index.go, 
+     store/search.go, etc.). Activate the Go profile for design guidance? → Yes
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ The design involves SQLite database access (store layer), so I should load the
+   database checklist.
+  Read 1 file (ctrl+o to expand)
+
+⏺ Good. All instructions loaded. Now let me execute Step 1 (understand the
+  project state) and Step 2 (check documentation) by exploring the relevant code
+   and docs.
+
+  Read 3 files (ctrl+o to expand)
+
+⏺ Now let me check the search fallback listing behavior and docs.
+
+  Read 1 file, listed 1 directory (ctrl+o to expand)
+
+⏺ Let me check the relevant ADRs and the tool registration to understand the MCP
+   schema surface.
+
+  Read 2 files (ctrl+o to expand)
+
+⏺ Good — I now have a complete picture of the codebase state. Let me also check
+  for prior arch decisions and conventions in the capy knowledge base, then
+  search the existing docs structure.
+
+  Listed 1 directory, called capy (ctrl+o to expand)
+
+⏺ Now I also notice something important — the search fallback listing at
+  tool_search.go:184-199 just dumped a massive unbounded source list. That's
+  exactly the bug described in the issue, and I just experienced it firsthand.
+  Good — confirms the problem is real.
+
+  Now I have full context. Let me proceed to Step 3 — refinement questions, one
+  at a time.
+
+  Task Progress:
+  - [x] Step 1: Understand the current state of the project
+  - [x] Step 2: Check the documentation
+  - [ ] Step 3: Help refine the idea/feature
+  - [ ] Step 4: Describe the design
+  - [ ] Step 5: Document the design
+  - [ ] Step 6: Create the task list
+
+  Here's my first refinement question:
+
+⏺ User answered Claude's questions:
+  ⎿  · For capy_fetch_and_index, should the default kind change to ephemeral 
+     (with opt-in durable), or should we keep durable as default but add a kind 
+     parameter? The tradeoff: ephemeral-default means existing users who fetch 
+     reference docs (API docs, library guides) lose cross-session persistence 
+     unless they pass kind:'durable'. Durable-default preserves backwards 
+     compatibility but doesn't fix the issue's core complaint about GitHub 
+     issues/PRs polluting the DB. → Ephemeral default is good. We're in 
+     pre-release, breaking things is ok. But we should provide AI instructions 
+     on when to use which somehow
+
+⏺ Good — ephemeral default for fetch, with guidance on when to opt into durable.
+   Next question:
+
+⏺ User answered Claude's questions:
+  ⎿  · For the AGENTS.md routing problem — the root cause is that tool 
+     descriptions and AGENTS.md both push agents toward capy for everything. The
+      fix needs two parts: (1) soften tool descriptions, (2) rewrite AGENTS.md 
+     routing rules. How aggressive should the AGENTS.md rewrite be? → Full 
+     rewrite
+
+⏺ User answered Claude's questions:
+  ⎿  · Should we add an explicit capy_promote tool, or is the implicit re-index 
+     promotion path (call capy_index on already-indexed content with the same 
+     label) sufficient? A dedicated tool is cleaner UX but adds API surface. → 
+     No new tool
+
+⏺ User answered Claude's questions:
+  ⎿  · The search fallback source listing (tool_search.go:184-199) is unbounded 
+     — I just saw it dump 100+ sources. How should it be capped? → what's your 
+     recommendation and why?
+
+⏺ I'd go with "Summary only" (option 3). Here's why:
+
+  The source listing exists to help the agent figure out what's available to 
+  search. But in practice, dumping source labels is rarely actionable — the
+  agent doesn't know which label contains the answer to its query. It's
+  cargo-cult helpfulness that costs real context tokens.
+
+  A single summary line ("12 durable sources (847 sections) indexed") gives the
+  agent the same signal: "there is content, your query just didn't match." If
+  the agent actually needs to browse sources, capy_stats already provides a
+  detailed breakdown — that's the right tool for introspection, not a search
+  fallback.
+
+  The per-query "ephemeral excluded" and "session excluded" hints
+  (tool_search.go:117-151) are already good — they tell the agent why it got no
+  results and how to fix it. Adding a source dump on top is noise that dilutes
+  those targeted hints.
+
+⏺ User answered Claude's questions:
+  ⎿  · Agree with summary-only approach for source listings? → Yes, summary only
+
+⏺ User answered Claude's questions:
+  ⎿  · Should capy_index also get a kind parameter (defaulting to durable), or 
+     should it stay hardcoded to durable? The argument for adding it: symmetry 
+     with fetch, and it enables the 're-index to promote' pattern more 
+     explicitly. The argument against: capy_index represents deliberate user 
+     intent to persist, adding kind muddies that signal. → Keep durable-only
+
+⏺ User answered Claude's questions:
+  ⎿  · The capy_execute tool description says 'MANDATORY: Use for any command 
+     where output exceeds 20 lines' and lists 'git log, git diff' as examples. 
+     This directly causes the review-code anti-pattern. Should we remove git 
+     commands from the capy_execute examples and explicitly list them as 'use 
+     Bash directly' in both the tool description and AGENTS.md? → Yes, all git 
+     via Bash
+
+⏺ Good. One final refinement question before I describe the design:
+
+⏺ User answered Claude's questions:
+  ⎿  · Since fetch_and_index will default to ephemeral, and effectiveKindFilter 
+     currently returns {durable, session} (excludes ephemeral), freshly fetched 
+     content won't appear in default searches. This breaks the current workflow 
+     of 'fetch then search'. Should we change the search default to include 
+     ephemeral? → Keep excluding ephemeral, but make sure the agent knows that 
+     fetch-then-search needs an extra search kind to be included
+
+⏺ All refinement questions answered. Let me now describe the design in sections.
+
+  ---
+  Section 1: Problem Statement & Solution Overview
+
+  This feature addresses two related problems from issue #44:
+
+  Problem A — Over-preservation. capy_fetch_and_index and capy_index hardcode
+  KindDurable, turning transient task artifacts (GitHub issues, PR pages,
+  investigation logs) into permanent DB residents. This causes knowledge DB
+  bloat and BM25 pollution — transient content competes with curated reference
+  docs in search ranking.
+
+  Problem B — Over-routing. AGENTS.md and tool descriptions push agents to route
+   all commands through capy, including operations where BM25-fragmented search
+  actively degrades quality. Code review sessions route git diff through
+  capy_batch_execute, destroying the sequential comprehension needed for proper
+  review. Small commands (git status, wc -l) get routed through sandbox+index
+  for zero context savings.
+
+  Solution: Two coordinated changes:
+  1. Storage fix: Add kind parameter to capy_fetch_and_index (default:
+  ephemeral). Update tool description and AGENTS.md to guide agents on when to
+  opt into kind: "durable".
+  2. Routing fix: Full rewrite of AGENTS.md and tool descriptions. Replace the
+  current "capy is the primary tool" framing with a task-aware decision tree:
+  comprehension tasks use direct tools; extraction tasks use capy. Cap the
+  search fallback source listing to a summary-only line.
+
+  Does this framing look right so far?
+
+✻ Churned for 2m 49s
+
+❯ yes                                                                           
+
+⏺ Section 2: Storage Changes — fetch_and_index kind parameter
+
+  The capy_fetch_and_index tool gets a new optional kind parameter accepting
+  "durable" or "ephemeral", defaulting to "ephemeral".
+
+  Code changes in internal/server/tool_fetch.go: The handler reads kind from
+  request arguments, validates it, and passes it to all three indexing call
+  sites (JSON, HTML→markdown, plain-text fallback) at lines 132-145. Currently
+  all three hardcode store.KindDurable — they'll use the resolved kind instead.
+
+  Code changes in internal/server/tools.go: The toolFetchAndIndex() definition
+  gains a new mcp.WithString("kind", ...) parameter with an enum of ["durable", 
+  "ephemeral"] and description explaining when to use each. The tool description
+   itself is updated to mention that fetched content is ephemeral by default and
+   won't appear in default searches — the agent must use source: or
+  include_kinds to query it afterward.
+
+  What stays unchanged:
+  - capy_index remains hardcoded KindDurable — it represents deliberate intent
+  to persist.
+  - capy_batch_execute auto-indexing remains KindEphemeral — correct already.
+  - The store layer's Index/IndexJSON/IndexPlainText methods already accept a
+  kind parameter — no store changes needed.
+  - The implicit promote/demote path in indexPreparedChunks (re-index same label
+   with different kind) continues working. No new capy_promote tool.
+
+  Impact on fetch-then-search workflow: Since ephemeral content is excluded from
+   default search, the fetch response preview (~3KB) is the primary way agents
+  consume fetched content. For deeper lookups, agents pass source: "<label>"
+  (which bypasses kind filtering) or include_kinds: ["durable", "ephemeral"].
+  The fetch response text already instructs this pattern: "use search(queries: 
+  [...], source: %q)" — the source: filter naturally works because it bypasses
+  kind filtering.
+
+  Does this section look right?
+
+✻ Sautéed for 17s
+
+❯ yes                                                                           
+
+⏺ Section 3: Search Fallback Listing Cap
+
+  The search handler's no-results path at tool_search.go:184-199 currently dumps
+   every indexed source label with chunk counts — completely unbounded. In the
+  gist session, this produced a massive source inventory that is itself context
+  pollution from capy's own control plane.
+
+  Change: Replace the per-source listing with a summary-only line. When no query
+   produces results and there are indexed sources available:
+
+  12 durable sources (847 sections) indexed. Refine your query terms, or use
+  capy_stats for source details.
+
+  The implementation at tool_search.go:184-199 currently calls st.ListSources(),
+   iterates all sources, filters by kind, and formats each as "label" (N 
+  sections). This gets replaced with a count query — the store already has
+  CountSourcesByKind() at search.go:546-556. We call it for each non-excluded
+  kind and format a single summary line.
+
+  What stays unchanged:
+  - The per-query "ephemeral excluded" and "session excluded" hints at lines
+  117-151 — these are targeted, actionable guidance that helps agents fix their
+  query. They stay.
+  - The throttle warnings at lines 172-177 — these are rate-limit feedback, not
+  source listings. They stay.
+  - capy_stats remains the right tool for detailed source browsing and
+  introspection.
+
+  Net effect: A no-results response drops from potentially thousands of
+  characters (one line per source × 100+ sources) to a single ~80 character
+  line. The ephemeral/session recovery hints still tell the agent why it got no
+  results and how to fix it.
+
+  Does this look right?
+
+✻ Crunched for 12s
+
+❯ yes                                                                           
+⏺ Section 4: AGENTS.md Full Rewrite & Tool Description Updates
+
+  This is the biggest change and addresses the routing/comprehension problem.
+  The core principle shift: from "capy is the primary tool, use Bash only for
+  exceptions" to "choose the tool based on what you need from the output."
+
+  New AGENTS.md structure:
+
+  1. Decision principle (replaces tool hierarchy). One sentence: "Use capy when
+  you need to extract specific facts from large output. Use direct tools (Bash,
+  Read) when you need to comprehend content fully." This replaces the current
+  "GATHER → FOLLOW-UP → PROCESSING → WEB → INDEX" numbered hierarchy that
+  positions capy_batch_execute as primary.
+  2. When to use capy (positive guidance). High-volume exploration passes (rg 
+  --files across a large repo, broad symbol searches), API responses you'll
+  query, fetching web pages for reference lookup, processing large log files.
+  The common thread: output is large (hundreds+ lines) and you only need
+  targeted facts, not full comprehension.
+  3. When NOT to use capy (anti-patterns — expanded from current). This section
+  is critical:
+    - Git commands always use Bash directly. Diffs, logs, status, branch — these
+   are comprehension content or small output. A code review needs the full diff
+  in context, not BM25 fragments. Remove git log, git diff from capy_execute
+  examples.
+    - Small-output commands use Bash directly. Anything producing <~50 lines: wc
+   -l, ls, git status, file, etc. The sandbox+index overhead exceeds any context
+   savings.
+    - Content you need to comprehend fully uses Read/Bash. Code review diffs,
+  files you'll edit, instruction documents, checklists — BM25 fragments destroy
+  structural relationships. This generalizes the existing anti-pattern about
+  instruction files.
+    - Sequential/ordered content uses Read/Bash. Diffs, logs, test output where
+  order matters — BM25 ranking reorders by relevance, losing the sequence.
+  4. Blocked commands (trimmed from current). Keep curl/wget/WebFetch blocks —
+  those are genuinely useful redirections. Remove the overly broad "Bash is ONLY
+   for" restriction.
+  5. Source kinds and search (updated). Reflects fetch_and_index defaulting to
+  ephemeral. Adds guidance: "After fetching, use source: '<label>' for follow-up
+   queries — this bypasses kind filtering."
+  6. Fetch durability guidance. New section: when to pass kind: "durable" to
+  fetch_and_index — API docs, library references, specifications you'll need
+  across sessions. Default ephemeral is right for: GitHub issues/PRs,
+  investigation artifacts, temporary task context.
+
+  Tool description changes in tools.go:
+
+  - capy_execute: Remove "MANDATORY" and "git queries (git log, git diff)" from
+  examples. Reframe as "for commands producing large output where you only need
+  extracted facts."
+  - capy_batch_execute: Remove "THIS IS THE PRIMARY TOOL." Reframe as "for broad
+   exploration passes where you need to run multiple commands and extract
+  specific answers."
+  - capy_fetch_and_index: Add note that content is ephemeral by default and
+  describe the kind parameter.
+
+  Does this look right?
+
+✻ Cogitated for 23s
+
+❯ yes                                                                           
+
+⏺ Section 5: ADR, Migration, and Edge Cases
+
+  New ADR (ADR-023). Documents the fetch default-kind change and the routing
+  philosophy shift. References ADR-017 (source-kind separation) as the
+  foundation this builds on. Key decisions to record:
+  - fetch_and_index defaults to ephemeral — rationale: most fetched content is
+  investigative task context, not curated knowledge.
+  - capy_index stays durable-only — rationale: explicit indexing = explicit
+  intent to persist.
+  - No capy_promote tool — implicit re-index via capy_index with same label
+  handles promotion.
+  - Routing rewrite from "capy-first" to "task-aware" — rationale: BM25
+  fragmentation destroys comprehension quality for diffs, reviews, and
+  sequential content.
+
+  Migration and backwards compatibility. No schema migration needed — the kind
+  column and its values already exist from ADR-017. The only behavioral change
+  is the default kind assigned by fetch_and_index. Existing durable rows from
+  prior fetches stay durable. New fetches without explicit kind: "durable" will
+  be ephemeral.
+
+  Edge cases to handle:
+  1. Fetch cache interaction. The TTL cache check at tool_fetch.go:53-68 looks
+  up by label. If a source was previously fetched as durable and is now
+  re-fetched (default ephemeral), the cache hit returns the old durable entry.
+  The force: true path bypasses cache and re-indexes — the store's
+  indexPreparedChunks will update the kind in-place. This is correct behavior:
+  cache respects existing content, force re-fetch respects new intent.
+  2. AGENTS.md injection into subagents. The current subagent routing block
+  (line 76-78) auto-injects AGENTS.md into spawned agents. The rewrite must
+  preserve this — subagents need the same routing guidance. No structural change
+   needed, just content update.
+  3. Cross-runtime compatibility. AGENTS.md is read by both Claude Code and
+  Codex. The rewrite must use plain language, not runtime-specific tool names.
+  Current AGENTS.md already does this (references MCP tool names which are
+  universal).
+  4. The capy_execute intent parameter. This auto-indexes large output as
+  ephemeral and returns BM25 results — correct for its use case (extracting from
+   command output). No change needed.
+
+  Does this look right?
+
+✻ Worked for 18s
+
+❯ yes, but the ADR should be documented now, not as a future task               
+
+⏺ You're right — the ADR captures the decision, and we've made the decisions.
+  Let me write it now.
+
+⏺ Write(docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
+  ⎿  Wrote 127 lines to
+     docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md
+      1 # ADR-023: Fetch ephemeral-by-default and task-aware routing rewr
+        ite
+      2 
+      4 **Date:** 2026-05-11
+      5 **Supersedes:** Amends ADR-017 (fetch_and_index kind assignment).
+      6 
+      7 ## Context
+      8 
+        d two related problems from production session transcript analysi
+        s (Codex and Claude Code):
+     … +229 lines (ctrl+o to expand)
+
+⏺ ADR-023 written. Now moving to Step 5 — documenting the full design and
+  implementation plan.
+
+  Ran 1 shell command (ctrl+o to expand)
+
+⏺ Write(docs/wip/issue-44-over-preservation-routing/design.md)
+  ⎿  Wrote 29 lines to
+     docs/wip/issue-44-over-preservation-routing/design.md
+      1 # Design: Fix over-preservation and over-routing (Issue #44)
+      2 
+      3 **Issue:** [#44](https://github.com/serpro69/capy/issues/44)
+        adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
+      5 **Status:** Design complete
+      6 
+      7 ## Overview
+      8 
+        cts in the knowledge DB and agents over-routing operations throug
+        h capy where it hurts quality.
+     … +38 lines (ctrl+o to expand)
+
+⏺ Write(docs/wip/issue-44-over-preservation-routing/implementation.md)
+  ⎿  Wrote 169 lines to
+     docs/wip/issue-44-over-preservation-routing/implementation.md
+       1 # Implementation Plan: Fix over-preservation and over-routing (I
+       2 
+       3 **Design:** [design.md](design.md)
+         -rewrite.md)
+       6 ## Prerequisites
+       7 
+         ver/tools.go`
+       9 - Understanding of the source-kind system from ADR-017: `kind` c
+         sion` constants in `internal/store/schema.go`
+         ch.go:558-571`
+     … +244 lines (ctrl+o to expand)
+
+⏺ Now Step 6 — the task list.
+
+  Read 1 file (ctrl+o to expand)
+
+⏺ Write(docs/wip/issue-44-over-preservation-routing/tasks.md)
+  ⎿  Wrote 64 lines to docs/wip/issue-44-over-preservation-routing/tasks.md
+       1 # Tasks: Fix over-preservation and over-routing (Issue #44)
+       2 
+       3 > Design: [./design.md](./design.md)
+       4 > Implementation: [./implementation.md](./implementation.md)
+       5 > ADR: [023-fetch-ephemeral-default-and-routing-rewrite](../../a
+       6 > Status: pending
+       7 > Created: 2026-05-11
+       8 
+       9 ## Task 1: Add `kind` parameter to `capy_fetch_and_index`
+      10 - **Status:** pending
+     … +90 lines (ctrl+o to expand)
+
+⏺ Task Progress:
+  - [x] Step 1: Understand the current state of the project
+  - [x] Step 2: Check the documentation
+  - [x] Step 3: Help refine the idea/feature
+  - [x] Step 4: Describe the design
+  - [x] Step 5: Document the design
+  - [x] Step 6: Create the task list
+
+  Design phase complete. Created:
+
+  - docs/adr/023-fetch-ephemeral-default-and-routing-rewrite.md — ADR
+  documenting all 5 decisions (fetch ephemeral default, no promote tool,
+  summary-only search fallback, AGENTS.md full rewrite, tool description
+  updates)
+  - docs/wip/issue-44-over-preservation-routing/design.md — Design overview and
+  decision table
+  - docs/wip/issue-44-over-preservation-routing/implementation.md — Detailed
+  implementation plan with file paths, line numbers, what to change/not change,
+  and verification steps
+  - docs/wip/issue-44-over-preservation-routing/tasks.md — 5 tasks with checkbox
+   subtasks, dependencies, and doc links
+
+  The work breaks down as: Task 1 (fetch kind param) and Task 2 (search cap) are
+   independent and can be done in parallel. Task 3 (tool descriptions) depends
+  on Task 1. Task 4 (AGENTS.md rewrite) depends on 1+3. Task 5 is final
+  verification.
+
+✻ Crunched for 3m 0s

--- a/docs/wip/issue-44-over-preservation-routing/.sessions/design-session.txt
+++ b/docs/wip/issue-44-over-preservation-routing/.sessions/design-session.txt
@@ -723,4 +723,4 @@
   on Task 1. Task 4 (AGENTS.md rewrite) depends on 1+3. Task 5 is final
   verification.
 
-✻ Crunched for 3m 0s
+✻ Crunched for 3m 0

--- a/docs/wip/issue-44-over-preservation-routing/design.md
+++ b/docs/wip/issue-44-over-preservation-routing/design.md
@@ -1,0 +1,29 @@
+# Design: Fix over-preservation and over-routing (Issue #44)
+
+**Issue:** [#44](https://github.com/serpro69/capy/issues/44)
+**ADR:** [023-fetch-ephemeral-default-and-routing-rewrite](../../adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
+**Status:** Design complete
+
+## Overview
+
+Two coordinated fixes addressing capy over-preserving task artifacts in the knowledge DB and agents over-routing operations through capy where it hurts quality.
+
+**Problem A (storage):** `capy_fetch_and_index` hardcodes `KindDurable`. Transient task artifacts (GitHub issues, PRs, investigation pages) become permanent DB residents, causing bloat and BM25 pollution.
+
+**Problem B (routing):** AGENTS.md and tool descriptions push agents to route all commands through capy — including git diffs for code review (destroying sequential comprehension via BM25 fragmentation) and small commands (pure overhead for <50 lines of output).
+
+**Problem C (control-plane noise):** The search handler's no-results fallback dumps an unbounded source listing — context pollution from capy's own output.
+
+## Design Decisions
+
+All decisions documented in [ADR-023](../../adr/023-fetch-ephemeral-default-and-routing-rewrite.md). Summary:
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| fetch_and_index default kind | `ephemeral` (opt-in `durable`) | Most fetched URLs are task-scoped; pre-release allows breaking change |
+| capy_index kind | Stays hardcoded `durable` | Explicit indexing = explicit persist intent |
+| Promote tool | No — implicit re-index promotion | Existing store path works; no new API surface |
+| Search fallback listing | Summary-only (count line) | Eliminate unbounded source dump |
+| AGENTS.md | Full rewrite — task-aware routing | "Comprehension vs extraction" principle replaces "capy-first" bias |
+| Tool descriptions | Soften mandatory/primary language | Remove git from capy_execute examples; reframe batch_execute |
+| Search default kinds | Keep {durable, session} | ADR-017 rationale preserved; source: filter handles fetch-then-search |

--- a/docs/wip/issue-44-over-preservation-routing/implementation.md
+++ b/docs/wip/issue-44-over-preservation-routing/implementation.md
@@ -70,9 +70,12 @@ Count only non-excluded kinds (respect `ephemeralExcluded` and `sessionExcluded`
 
 The `ListSources()` call is no longer needed in this path — remove it. If `ListSources` is unused elsewhere after this change, leave it (it's a store-layer method that may have other consumers or future uses).
 
+**`internal/server/tool_search.go` — ephemeral-excluded hint (lines 126-131):**
+Update the hint text. Currently it says `"To include command output from capy_execute / capy_execute_file / capy_batch_execute"` — after fetch defaults to ephemeral, this is incomplete. Change to mention that ephemeral sources now include both command output and fetched web pages. Add `source: "<label>"` as a recovery path (it's already in the session-excluded hint pattern but missing from the ephemeral one).
+
 ### What NOT to change
 
-- Per-query "ephemeral excluded" / "session excluded" hints at lines 117-151 — these are targeted and actionable. Keep them.
+- Per-query "session excluded" hints at lines 134-150 — these are already correct. Keep them.
 - Throttle warnings at lines 172-177 — keep them.
 - The `ListSources` store method itself — don't delete it; other code paths or `capy_stats` may use it.
 
@@ -106,7 +109,13 @@ The `ListSources()` call is no longer needed in this path — remove it. If `Lis
 
 ### What NOT to change
 
-- `toolIndex()`, `toolExecuteFile()`, `toolStats()`, `toolDoctor()`, `toolCleanup()` — no changes needed.
+**`internal/server/tools.go` — `toolExecuteFile()` (lines 145-172):**
+- Soften "PREFER THIS OVER Read/cat for: log files, data files (CSV, JSON, XML), large source files for analysis." — the "PREFER THIS OVER Read" language contradicts the new comprehension-vs-extraction principle where Read is the default.
+- Reframe: "Read a file and process it without loading contents into context. Best for large files (10k+ lines) where you only need derived answers (counts, patterns, structural summary). Read is correct when you need to understand or edit the file. Available: [%s]."
+
+### What NOT to change
+
+- `toolIndex()`, `toolStats()`, `toolDoctor()`, `toolCleanup()` — no changes needed.
 - Tool annotations (read-only/destructive hints) — no changes.
 
 ### Verify
@@ -180,7 +189,10 @@ Review `GREP_GUIDANCE` and `READ_GUIDANCE` — these may be fine as-is since the
 
 - `CLAUDE.md` reference to AGENTS.md (`@.capy/AGENTS.md`) — keep the include.
 - `.claude/CLAUDE.extra.md` — no changes needed.
-- `internal/hook/pretooluse.go` and `internal/hook/sessionstart.go` — these are injection points, not content sources. They call `RoutingBlock()` which we're updating.
+- `internal/hook/sessionstart.go` — injection point only; calls `RoutingBlock()` which we're updating.
+
+**`internal/hook/pretooluse.go` — build-tool redirect (lines 111-116):**
+`isBuildTool()` hard-redirects Gradle/Maven commands to `capy_execute`. Build output is sequential — test results, compilation errors, dependency resolution — where order matters for comprehension. This contradicts the new "sequential/ordered content uses direct tools" principle. Review and decide: either remove the redirect entirely (let AGENTS.md guidance handle it), soften it to a guidance nudge (like `BASH_GUIDANCE`), or keep it with a documented exception explaining why build output specifically benefits from sandbox extraction despite being sequential. The decision should be consistent with how we treat other large-output commands under the new routing principle.
 - `internal/platform/setup.go` — the setup logic that writes routing to disk and replaces stale blocks stays the same; only the content from `GenerateRoutingInstructions()` changes.
 
 ### Verify

--- a/docs/wip/issue-44-over-preservation-routing/implementation.md
+++ b/docs/wip/issue-44-over-preservation-routing/implementation.md
@@ -71,7 +71,7 @@ Count only non-excluded kinds (respect `ephemeralExcluded` and `sessionExcluded`
 The `ListSources()` call is no longer needed in this path — remove it. If `ListSources` is unused elsewhere after this change, leave it (it's a store-layer method that may have other consumers or future uses).
 
 **`internal/server/tool_search.go` — ephemeral-excluded hint (lines 126-131):**
-Update the hint text. Currently it says `"To include command output from capy_execute / capy_execute_file / capy_batch_execute"` — after fetch defaults to ephemeral, this is incomplete. Change to mention that ephemeral sources now include both command output and fetched web pages. Add `source: "<label>"` as a recovery path (it's already in the session-excluded hint pattern but missing from the ephemeral one).
+Update the hint text. Currently it says `"To include command output from capy_execute / capy_execute_file / capy_batch_execute"` — after fetch defaults to ephemeral, this is incomplete. Change to mention that ephemeral sources now include both command output (capy_execute / capy_execute_file / capy_batch_execute) and fetched web pages (capy_fetch_and_index). Add `source: "<label>"` as a recovery path (it's already in the session-excluded hint pattern but missing from the ephemeral one).
 
 ### What NOT to change
 
@@ -106,8 +106,6 @@ Update the hint text. Currently it says `"To include command output from capy_ex
 **`internal/server/tools.go` — `toolSearch()` (lines 190-209):**
 - Fix the main description (line 193): change `"By default returns only durable sources (fetched/indexed reference content)"` to `"By default returns durable and session sources"`. Remove the parenthetical that calls fetched content "reference content" — after this change, fetched content is ephemeral by default.
 - Fix the `include_kinds` description (line 205): change `"Default: [\"durable\"] only"` to `"Default: [\"durable\", \"session\"]"` to match the actual behavior in `effectiveKindFilter` at `search.go:569`. Update the `"durable"` parenthetical from `"fetched/indexed reference content, retained by retention score"` to `"explicitly indexed reference content, retained by retention score"` since fetched content is no longer durable by default.
-
-### What NOT to change
 
 **`internal/server/tools.go` — `toolExecuteFile()` (lines 145-172):**
 - Soften "PREFER THIS OVER Read/cat for: log files, data files (CSV, JSON, XML), large source files for analysis." — the "PREFER THIS OVER Read" language contradicts the new comprehension-vs-extraction principle where Read is the default.

--- a/docs/wip/issue-44-over-preservation-routing/implementation.md
+++ b/docs/wip/issue-44-over-preservation-routing/implementation.md
@@ -17,9 +17,9 @@
 Add a new optional `kind` string parameter with enum `["durable", "ephemeral"]`. Update the tool description to mention ephemeral default and the `source:` filter pattern for follow-up search.
 
 **`internal/server/tool_fetch.go` — `handleFetchAndIndex()` function (line 33-165):**
-1. Read the `kind` argument from request. Default to `store.KindEphemeral` if absent or empty.
-2. Validate: must be `"durable"` or `"ephemeral"` (use `store.SourceKind.Valid()` — but note it also accepts `"session"`, so validate explicitly against the two allowed values).
-3. Replace all three `store.KindDurable` literals at lines 132, 138, 141, 145 with the resolved kind variable.
+1. Read and validate the `kind` argument **before** the TTL cache check (before line 52). Default to `store.KindEphemeral` if absent or empty. Validate explicitly against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values). This must happen first because the cache check needs to compare the requested kind against the cached kind.
+2. Modify the TTL cache check (lines 52-68): after finding a cache hit, compare `meta.Kind` (available on `SourceMeta` at `internal/store/types.go:100`) against the requested kind. If they differ, bypass the cache and proceed with re-fetch+re-index so the kind change takes effect. This prevents the cache from silently swallowing kind changes (e.g., a previously-durable source that should now be ephemeral).
+3. Replace all four `store.KindDurable` literals at lines 132, 138, 141, 145 with the resolved kind variable.
 4. Update the response text (line 159-163) to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for follow-up queries on ephemeral content.
 
 ### What NOT to change
@@ -37,6 +37,9 @@ Add a new optional `kind` string parameter with enum `["durable", "ephemeral"]`.
   - Fetches with `kind: "durable"` → assert stored as durable
   - Fetches with `kind: "ephemeral"` → assert stored as ephemeral
   - Fetches with `kind: "invalid"` → assert error response
+  - Fetches with `kind: "session"` → assert error response
+  - Fetches a URL as durable, then re-fetches same URL with `kind: "ephemeral"` (within cache TTL) → assert cache is bypassed and kind is updated to ephemeral
+  - Fetches a URL (default ephemeral), then re-fetches same URL with `kind: "durable"` → assert cache is bypassed and kind is updated to durable
 
 ## Task 2: Cap search fallback source listing
 
@@ -56,14 +59,14 @@ if len(parts) > 0 {
 }
 ```
 
-With a summary-only approach using `CountSourcesByKind`:
+With a summary-only approach using `CountSourcesByKind` (which returns source count only — section count is not needed for a directional summary):
 ```
 durableCount, _ := st.CountSourcesByKind(store.KindDurable)
-// Also count session if not excluded, for a combined total
+// Also count session if not excluded
 // Format: "12 durable sources indexed. Refine your query terms, or use capy_stats for source details."
 ```
 
-Count only non-excluded kinds (respect `ephemeralExcluded` and `sessionExcluded` flags already computed at lines 96-97). Format a single line with the count and a pointer to `capy_stats`.
+Count only non-excluded kinds (respect `ephemeralExcluded` and `sessionExcluded` flags already computed at lines 96-97). Format a single line with source counts per kind and a pointer to `capy_stats`. Section counts are intentionally omitted — the source count is sufficient to tell the agent "content exists, your query didn't match" and `capy_stats` provides the detailed breakdown.
 
 The `ListSources()` call is no longer needed in this path — remove it. If `ListSources` is unused elsewhere after this change, leave it (it's a store-layer method that may have other consumers or future uses).
 
@@ -97,9 +100,13 @@ The `ListSources()` call is no longer needed in this path — remove it. If `Lis
 **`internal/server/tools.go` — `toolFetchAndIndex()` (lines 211-226):**
 - Update description to mention ephemeral default: "Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions."
 
+**`internal/server/tools.go` — `toolSearch()` (lines 190-209):**
+- Fix the main description (line 193): change `"By default returns only durable sources (fetched/indexed reference content)"` to `"By default returns durable and session sources"`. Remove the parenthetical that calls fetched content "reference content" — after this change, fetched content is ephemeral by default.
+- Fix the `include_kinds` description (line 205): change `"Default: [\"durable\"] only"` to `"Default: [\"durable\", \"session\"]"` to match the actual behavior in `effectiveKindFilter` at `search.go:569`. Update the `"durable"` parenthetical from `"fetched/indexed reference content, retained by retention score"` to `"explicitly indexed reference content, retained by retention score"` since fetched content is no longer durable by default.
+
 ### What NOT to change
 
-- `toolSearch()`, `toolIndex()`, `toolExecuteFile()`, `toolStats()`, `toolDoctor()`, `toolCleanup()` — no changes needed.
+- `toolIndex()`, `toolExecuteFile()`, `toolStats()`, `toolDoctor()`, `toolCleanup()` — no changes needed.
 - Tool annotations (read-only/destructive hints) — no changes.
 
 ### Verify
@@ -107,7 +114,17 @@ The `ListSources()` call is no longer needed in this path — remove it. If `Lis
 - `go build ./...` compiles
 - Manual inspection: start capy MCP server, call `tools/list`, verify updated descriptions render correctly in the tool listing.
 
-## Task 4: Full AGENTS.md rewrite
+## Task 4: Full routing rewrite (AGENTS.md + generated routing blocks)
+
+### Important: Three routing surfaces
+
+There are three places where routing rules live — all three must be updated together:
+
+1. **`.capy/AGENTS.md`** — the static file read by agents directly from the repo.
+2. **`internal/platform/routing.go:18` — `GenerateRoutingInstructions()`** — generates the same routing block that `capy setup` writes into CLAUDE.md/AGENTS.md. Contains the identical "MANDATORY", "ONLY for", "Primary tool" language. This is the source-of-truth for the file-based routing block.
+3. **`internal/hook/routing.go:6` — `RoutingBlock()`** — the XML routing block injected at runtime into subagent prompts (via `pretooluse.go:139`) and session start (via `sessionstart.go:6`). Contains "You MUST use capy", "Primary tool for research", "DO NOT use Bash for commands producing >20 lines", "Bash is ONLY for git/mkdir/rm/mv/navigation". Plus the guidance constants `BASH_GUIDANCE`, `GREP_GUIDANCE`, `READ_GUIDANCE` at lines 57-84.
+
+Rewriting only AGENTS.md leaves the runtime-injected routing (`RoutingBlock()`) and the setup-generated routing (`GenerateRoutingInstructions()`) still pushing the old "capy-first" behavior. Subagents in particular get their routing from `RoutingBlock()`, not from AGENTS.md.
 
 ### What to change
 
@@ -145,11 +162,26 @@ The new document structure:
 
 10. **capy commands table.** Carry forward: `capy stats`, `capy doctor`.
 
+**`internal/platform/routing.go` — `GenerateRoutingInstructions()` (line 18-111):**
+Rewrite the generated routing block to match the new AGENTS.md content. This function should produce the same task-aware routing text as AGENTS.md. The content is written to disk during `capy setup`, so it must be self-contained (no @-imports).
+
+**`internal/hook/routing.go` — `RoutingBlock()` (line 6-54):**
+Rewrite the XML routing block to match the new task-aware routing principle. Key changes:
+- Replace `"You MUST use capy MCP tools"` with the comprehension-vs-extraction decision principle.
+- Replace `"Primary tool for research"` in the hierarchy with extraction-focused guidance.
+- Replace `"DO NOT use Bash for commands producing >20 lines"` with the nuanced rule (Bash for git, small commands, comprehension content).
+- Replace `"Bash is ONLY for git/mkdir/rm/mv/navigation"` with the positive framing.
+
+**`internal/hook/routing.go` — guidance constants (lines 57-84):**
+Update `BASH_GUIDANCE` (line 76-84): replace `"Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only"` with task-aware guidance that doesn't imply Bash is a last resort.
+Review `GREP_GUIDANCE` and `READ_GUIDANCE` — these may be fine as-is since they already provide nuanced advice.
+
 ### What NOT to change
 
 - `CLAUDE.md` reference to AGENTS.md (`@.capy/AGENTS.md`) — keep the include.
 - `.claude/CLAUDE.extra.md` — no changes needed.
-- Hook configurations or settings — no changes.
+- `internal/hook/pretooluse.go` and `internal/hook/sessionstart.go` — these are injection points, not content sources. They call `RoutingBlock()` which we're updating.
+- `internal/platform/setup.go` — the setup logic that writes routing to disk and replaces stale blocks stays the same; only the content from `GenerateRoutingInstructions()` changes.
 
 ### Verify
 

--- a/docs/wip/issue-44-over-preservation-routing/implementation.md
+++ b/docs/wip/issue-44-over-preservation-routing/implementation.md
@@ -1,0 +1,169 @@
+# Implementation Plan: Fix over-preservation and over-routing (Issue #44)
+
+**Design:** [design.md](design.md)
+**ADR:** [023](../../adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
+
+## Prerequisites
+
+- Familiarity with capy's MCP tool registration in `internal/server/tools.go`
+- Understanding of the source-kind system from ADR-017: `kind` column on `sources` table, `KindDurable`/`KindEphemeral`/`KindSession` constants in `internal/store/schema.go`
+- Understanding of `effectiveKindFilter` in `internal/store/search.go:558-571`
+
+## Task 1: Add `kind` parameter to `capy_fetch_and_index`
+
+### What to change
+
+**`internal/server/tools.go` — `toolFetchAndIndex()` function (line 211-226):**
+Add a new optional `kind` string parameter with enum `["durable", "ephemeral"]`. Update the tool description to mention ephemeral default and the `source:` filter pattern for follow-up search.
+
+**`internal/server/tool_fetch.go` — `handleFetchAndIndex()` function (line 33-165):**
+1. Read the `kind` argument from request. Default to `store.KindEphemeral` if absent or empty.
+2. Validate: must be `"durable"` or `"ephemeral"` (use `store.SourceKind.Valid()` — but note it also accepts `"session"`, so validate explicitly against the two allowed values).
+3. Replace all three `store.KindDurable` literals at lines 132, 138, 141, 145 with the resolved kind variable.
+4. Update the response text (line 159-163) to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for follow-up queries on ephemeral content.
+
+### What NOT to change
+
+- `internal/server/tool_index.go` — `handleIndex()` stays hardcoded `KindDurable`.
+- `internal/server/tool_batch.go` — `handleBatchExecute()` stays hardcoded `KindEphemeral`.
+- `internal/store/` — no store changes. `Index`, `IndexJSON`, `IndexPlainText` already accept `kind` parameter.
+
+### Verify
+
+- `go build ./...` compiles
+- `go test -tags fts5 ./internal/server/...` passes
+- Write a test in `tool_fetch_test.go` that:
+  - Fetches a URL with no `kind` param → assert stored as ephemeral
+  - Fetches with `kind: "durable"` → assert stored as durable
+  - Fetches with `kind: "ephemeral"` → assert stored as ephemeral
+  - Fetches with `kind: "invalid"` → assert error response
+
+## Task 2: Cap search fallback source listing
+
+### What to change
+
+**`internal/server/tool_search.go` — no-results source listing (lines 184-199):**
+
+Replace the current block:
+```
+sources, _ := st.ListSources()
+var parts []string
+for _, src := range sources {
+    // ... format each source
+}
+if len(parts) > 0 {
+    output += "\n\nIndexed sources: " + strings.Join(parts, ", ")
+}
+```
+
+With a summary-only approach using `CountSourcesByKind`:
+```
+durableCount, _ := st.CountSourcesByKind(store.KindDurable)
+// Also count session if not excluded, for a combined total
+// Format: "12 durable sources indexed. Refine your query terms, or use capy_stats for source details."
+```
+
+Count only non-excluded kinds (respect `ephemeralExcluded` and `sessionExcluded` flags already computed at lines 96-97). Format a single line with the count and a pointer to `capy_stats`.
+
+The `ListSources()` call is no longer needed in this path — remove it. If `ListSources` is unused elsewhere after this change, leave it (it's a store-layer method that may have other consumers or future uses).
+
+### What NOT to change
+
+- Per-query "ephemeral excluded" / "session excluded" hints at lines 117-151 — these are targeted and actionable. Keep them.
+- Throttle warnings at lines 172-177 — keep them.
+- The `ListSources` store method itself — don't delete it; other code paths or `capy_stats` may use it.
+
+### Verify
+
+- `go test -tags fts5 ./internal/server/...` passes
+- Write/update a test that triggers the no-results path with multiple indexed sources and asserts:
+  - Output contains a count summary (e.g., "12 durable sources")
+  - Output does NOT contain individual source labels
+  - Output still contains the ephemeral/session hints when applicable
+
+## Task 3: Update tool descriptions in `tools.go`
+
+### What to change
+
+**`internal/server/tools.go` — `toolExecute()` (lines 117-143):**
+- Remove "MANDATORY: Use for any command where output exceeds 20 lines." prefix.
+- Remove "git queries (git log, git diff)" from the example list.
+- Reframe description: "Execute code in a sandboxed subprocess for large-output extraction. Only stdout enters context — raw data stays in the subprocess. Best for: API calls, broad searches (rg, grep), log analysis, data processing, and commands producing hundreds+ lines where you only need extracted facts. NOT for: git commands (use Bash), small-output commands (<50 lines, use Bash), content you need to comprehend fully (use Read/Bash)."
+
+**`internal/server/tools.go` — `toolBatchExecute()` (lines 228-253):**
+- Remove "THIS IS THE PRIMARY TOOL." from description.
+- Reframe: "Execute multiple commands in ONE call, auto-index all output, and search with multiple queries. Returns search results directly — no follow-up calls needed. Best for broad exploration passes where you need to run multiple commands and extract specific answers from combined output. NOT for: git diffs, small commands, or content you need to read fully."
+
+**`internal/server/tools.go` — `toolFetchAndIndex()` (lines 211-226):**
+- Update description to mention ephemeral default: "Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions."
+
+### What NOT to change
+
+- `toolSearch()`, `toolIndex()`, `toolExecuteFile()`, `toolStats()`, `toolDoctor()`, `toolCleanup()` — no changes needed.
+- Tool annotations (read-only/destructive hints) — no changes.
+
+### Verify
+
+- `go build ./...` compiles
+- Manual inspection: start capy MCP server, call `tools/list`, verify updated descriptions render correctly in the tool listing.
+
+## Task 4: Full AGENTS.md rewrite
+
+### What to change
+
+**`.capy/AGENTS.md` — complete rewrite.**
+
+The new document structure:
+
+1. **Header and purpose.** Capy MCP tools are available for context-window protection. One sentence on what capy does.
+
+2. **Decision principle.** "Choose the tool based on what you need from the output: *comprehension* (you need to understand the full content) → direct tools (Bash, Read). *Extraction* (you need specific facts from large output) → capy tools."
+
+3. **When to use direct tools (Bash / Read).** Positive list:
+   - Git commands: diffs, logs, status, branch — always Bash. Diffs are comprehension content; BM25 fragments destroy review quality.
+   - Small-output commands (<~50 lines): ls, wc, file, git status — Bash directly.
+   - Files you need to comprehend or edit: Read tool. Required before Edit.
+   - Sequential/ordered content: test output, build logs where order matters — Bash or Read.
+   - Instruction files, checklists, configs: Read and internalize whole (carry forward existing anti-pattern from current AGENTS.md).
+
+4. **When to use capy tools.** Positive list:
+   - `capy_batch_execute`: Broad exploration — multiple commands + queries in one call. Example: initial repo scan with `rg --files` + symbol searches.
+   - `capy_execute` / `capy_execute_file`: Single command or file producing hundreds+ lines where you only need extracted facts. API calls, log analysis, data processing.
+   - `capy_fetch_and_index`: Fetch web content for reference lookup. Default ephemeral (24h). Pass `kind: "durable"` for reference docs (API docs, library guides, specs). Use `source: "<label>"` for follow-up search.
+   - `capy_index`: Persist curated knowledge durably. For content you explicitly want searchable across sessions.
+   - `capy_search`: Query indexed content. Batch all questions as array. Use `source:` to scope. Default excludes ephemeral — use `include_kinds` or `source:` to include.
+
+5. **Blocked commands.** Keep: curl/wget, inline HTTP, WebFetch blocks. These are genuine SSRF/context-flood protections.
+
+6. **Source kinds table.** Updated to reflect fetch → ephemeral default. Include guidance on fetch-then-search pattern (use `source:` filter).
+
+7. **Read vs capy_execute_file.** Carry forward existing guidance — it's already well-written. "Default to Read. Reach for capy_execute_file only when file is genuinely large AND you want a derived answer AND you can write the exact script upfront."
+
+8. **Output constraints.** Carry forward: 500-word limit, artifacts to files, descriptive source labels.
+
+9. **Subagent routing.** Carry forward: routing block auto-injected, Bash agents upgraded to general-purpose.
+
+10. **capy commands table.** Carry forward: `capy stats`, `capy doctor`.
+
+### What NOT to change
+
+- `CLAUDE.md` reference to AGENTS.md (`@.capy/AGENTS.md`) — keep the include.
+- `.claude/CLAUDE.extra.md` — no changes needed.
+- Hook configurations or settings — no changes.
+
+### Verify
+
+- Read the final AGENTS.md as an AI agent would: does the routing guidance unambiguously tell you to use Bash for `git diff` during code review? Does it tell you to use capy for a broad `rg` search across a large repo? If both answers are yes, the rewrite works.
+- Verify no orphaned references: if the current AGENTS.md is referenced by other docs, update those references.
+
+## Task 5: Final verification
+
+### What to do
+
+1. Run `go build ./...` — verify compilation.
+2. Run `go test -tags fts5 ./...` — verify all tests pass.
+3. Start capy as MCP server, call `tools/list`, verify tool descriptions.
+4. Run `kk:review-code` to review all changes.
+5. Run `kk:test` to verify test coverage.
+6. Run `kk:document` to update any relevant documentation.
+7. Run `kk:review-spec` to verify implementation matches this design doc and ADR-023.

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -33,17 +33,17 @@
 - [x] 2.5 Verify: `go test -tags fts5 ./internal/server/...`
 
 ## Task 3: Update tool descriptions
-- **Status:** pending
+- **Status:** done
 - **Depends on:** Task 1
 - **Docs:** [implementation.md § Task 3](./implementation.md#task-3-update-tool-descriptions-in-toolsgo)
 
 ### Subtasks
-- [ ] 3.1 `toolExecute()` in `tools.go`: remove "MANDATORY" prefix, remove "git queries (git log, git diff)" from examples, reframe as extraction tool with positive/negative guidance
-- [ ] 3.2 `toolBatchExecute()` in `tools.go`: remove "THIS IS THE PRIMARY TOOL", reframe as broad exploration/extraction tool with "NOT for" guidance
-- [ ] 3.3 `toolFetchAndIndex()` in `tools.go`: update description to mention ephemeral default, `kind` parameter, and `source:` filter pattern for follow-up search
-- [ ] 3.4 `toolSearch()` in `tools.go`: fix stale description — change default from "durable only" to "durable and session", remove "fetched/indexed reference content" parenthetical, update `include_kinds` help text to match actual `effectiveKindFilter` behavior
-- [ ] 3.5 `toolExecuteFile()` in `tools.go`: soften "PREFER THIS OVER Read/cat" to align with comprehension-vs-extraction principle. Reframe: "for large files (10k+ lines) where you only need derived answers. Read is correct when you need to understand or edit the file."
-- [ ] 3.6 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
+- [x] 3.1 `toolExecute()` in `tools.go`: remove "MANDATORY" prefix, remove "git queries (git log, git diff)" from examples, reframe as extraction tool with positive/negative guidance
+- [x] 3.2 `toolBatchExecute()` in `tools.go`: remove "THIS IS THE PRIMARY TOOL", reframe as broad exploration/extraction tool with "NOT for" guidance
+- [x] 3.3 `toolFetchAndIndex()` in `tools.go`: update description to mention ephemeral default, `kind` parameter, and `source:` filter pattern for follow-up search
+- [x] 3.4 `toolSearch()` in `tools.go`: fix stale description — change default from "durable only" to "durable and session", remove "fetched/indexed reference content" parenthetical, update `include_kinds` help text to match actual `effectiveKindFilter` behavior
+- [x] 3.5 `toolExecuteFile()` in `tools.go`: soften "PREFER THIS OVER Read/cat" to align with comprehension-vs-extraction principle. Reframe: "for large files (10k+ lines) where you only need derived answers. Read is correct when you need to understand or edit the file."
+- [x] 3.6 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
 
 ## Task 4: Full routing rewrite (AGENTS.md + generated routing blocks)
 - **Status:** pending

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Fix over-preservation and over-routing (Issue #44)
+
+> Design: [./design.md](./design.md)
+> Implementation: [./implementation.md](./implementation.md)
+> ADR: [023-fetch-ephemeral-default-and-routing-rewrite](../../adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
+> Status: pending
+> Created: 2026-05-11
+
+## Task 1: Add `kind` parameter to `capy_fetch_and_index`
+- **Status:** pending
+- **Depends on:** —
+- **Docs:** [implementation.md § Task 1](./implementation.md#task-1-add-kind-parameter-to-capy_fetch_and_index)
+
+### Subtasks
+- [ ] 1.1 Add optional `kind` string parameter (enum: `["durable", "ephemeral"]`) to `toolFetchAndIndex()` in `internal/server/tools.go`
+- [ ] 1.2 In `handleFetchAndIndex()` (`internal/server/tool_fetch.go`): read `kind` from request, default to `store.KindEphemeral`, validate against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values)
+- [ ] 1.3 Replace all four `store.KindDurable` literals at the indexing call sites (lines 132, 138, 141, 145) with the resolved kind variable
+- [ ] 1.4 Update the response text to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for ephemeral follow-up queries
+- [ ] 1.5 Add tests in `tool_fetch_test.go`: no-kind → ephemeral, `kind: "durable"` → durable, `kind: "ephemeral"` → ephemeral, `kind: "invalid"` → error, `kind: "session"` → error
+- [ ] 1.6 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
+
+## Task 2: Cap search fallback source listing
+- **Status:** pending
+- **Depends on:** —
+- **Docs:** [implementation.md § Task 2](./implementation.md#task-2-cap-search-fallback-source-listing)
+
+### Subtasks
+- [ ] 2.1 In `handleSearch()` (`internal/server/tool_search.go` lines 184-199): replace the `ListSources()` + per-source formatting loop with `CountSourcesByKind()` calls for non-excluded kinds
+- [ ] 2.2 Format a single summary line: count of sources and sections for each included kind, plus pointer to `capy_stats` for details
+- [ ] 2.3 Write/update test: trigger no-results with multiple indexed sources → assert output contains count summary, does NOT contain individual source labels, still contains ephemeral/session hints when applicable
+- [ ] 2.4 Verify: `go test -tags fts5 ./internal/server/...`
+
+## Task 3: Update tool descriptions
+- **Status:** pending
+- **Depends on:** Task 1
+- **Docs:** [implementation.md § Task 3](./implementation.md#task-3-update-tool-descriptions-in-toolsgo)
+
+### Subtasks
+- [ ] 3.1 `toolExecute()` in `tools.go`: remove "MANDATORY" prefix, remove "git queries (git log, git diff)" from examples, reframe as extraction tool with positive/negative guidance
+- [ ] 3.2 `toolBatchExecute()` in `tools.go`: remove "THIS IS THE PRIMARY TOOL", reframe as broad exploration/extraction tool with "NOT for" guidance
+- [ ] 3.3 `toolFetchAndIndex()` in `tools.go`: update description to mention ephemeral default, `kind` parameter, and `source:` filter pattern for follow-up search
+- [ ] 3.4 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
+
+## Task 4: Full AGENTS.md rewrite
+- **Status:** pending
+- **Depends on:** Task 1, Task 3
+- **Docs:** [implementation.md § Task 4](./implementation.md#task-4-full-agentsmd-rewrite)
+
+### Subtasks
+- [ ] 4.1 Write new `.capy/AGENTS.md` with task-aware routing structure: decision principle, when to use direct tools, when to use capy, blocked commands, source kinds, Read vs capy_execute_file, output constraints, subagent routing, capy commands
+- [ ] 4.2 Verify routing clarity: does the document unambiguously route `git diff` to Bash? Does it route broad `rg` to capy? Does it explain when to pass `kind: "durable"` to fetch?
+- [ ] 4.3 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
+
+## Task 5: Final verification
+- **Status:** pending
+- **Depends on:** Task 1, Task 2, Task 3, Task 4
+
+### Subtasks
+- [ ] 5.1 Run `go build ./...` — verify compilation
+- [ ] 5.2 Run `go test -tags fts5 ./...` — verify all tests pass
+- [ ] 5.3 Run `kk:test` to verify test coverage for new/changed code
+- [ ] 5.4 Run `kk:document` to update any relevant documentation
+- [ ] 5.5 Run `kk:review-code` with Go profile to review all changes
+- [ ] 5.6 Run `kk:review-spec` to verify implementation matches design.md, implementation.md, and ADR-023

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -7,18 +7,18 @@
 > Created: 2026-05-11
 
 ## Task 1: Add `kind` parameter to `capy_fetch_and_index`
-- **Status:** pending
+- **Status:** done
 - **Depends on:** —
 - **Docs:** [implementation.md § Task 1](./implementation.md#task-1-add-kind-parameter-to-capy_fetch_and_index)
 
 ### Subtasks
-- [ ] 1.1 Add optional `kind` string parameter (enum: `["durable", "ephemeral"]`) to `toolFetchAndIndex()` in `internal/server/tools.go`
-- [ ] 1.2 In `handleFetchAndIndex()` (`internal/server/tool_fetch.go`): read and validate `kind` **before** the TTL cache check (before line 52). Default to `store.KindEphemeral`, validate against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values)
-- [ ] 1.3 Modify the TTL cache check (lines 52-68): after cache hit, compare `meta.Kind` against requested kind. If they differ, bypass cache and proceed with re-fetch+re-index
-- [ ] 1.4 Replace all four `store.KindDurable` literals at the indexing call sites (lines 132, 138, 141, 145) with the resolved kind variable
-- [ ] 1.5 Update the response text to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for ephemeral follow-up queries
-- [ ] 1.6 Add tests in `tool_fetch_test.go`: no-kind → ephemeral, `kind: "durable"` → durable, `kind: "ephemeral"` → ephemeral, `kind: "invalid"` → error, `kind: "session"` → error, cache-hit with kind mismatch → cache bypassed and kind updated
-- [ ] 1.7 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
+- [x] 1.1 Add optional `kind` string parameter (enum: `["durable", "ephemeral"]`) to `toolFetchAndIndex()` in `internal/server/tools.go`
+- [x] 1.2 In `handleFetchAndIndex()` (`internal/server/tool_fetch.go`): read and validate `kind` **before** the TTL cache check (before line 52). Default to `store.KindEphemeral`, validate against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values)
+- [x] 1.3 Modify the TTL cache check (lines 52-68): after cache hit, compare `meta.Kind` against requested kind. If they differ, bypass cache and proceed with re-fetch+re-index
+- [x] 1.4 Replace all four `store.KindDurable` literals at the indexing call sites (lines 132, 138, 141, 145) with the resolved kind variable
+- [x] 1.5 Update the response text to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for ephemeral follow-up queries
+- [x] 1.6 Add tests in `tool_fetch_test.go`: no-kind → ephemeral, `kind: "durable"` → durable, `kind: "ephemeral"` → ephemeral, `kind: "invalid"` → error, `kind: "session"` → error, cache-hit with kind mismatch → cache bypassed and kind updated
+- [x] 1.7 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
 
 ## Task 2: Cap search fallback source listing
 - **Status:** pending

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -3,7 +3,7 @@
 > Design: [./design.md](./design.md)
 > Implementation: [./implementation.md](./implementation.md)
 > ADR: [023-fetch-ephemeral-default-and-routing-rewrite](../../adr/023-fetch-ephemeral-default-and-routing-rewrite.md)
-> Status: pending
+> Status: done
 > Created: 2026-05-11
 
 ## Task 1: Add `kind` parameter to `capy_fetch_and_index`
@@ -62,13 +62,13 @@
 - [x] 4.9 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
 
 ## Task 5: Final verification
-- **Status:** pending
+- **Status:** done
 - **Depends on:** Task 1, Task 2, Task 3, Task 4
 
 ### Subtasks
-- [ ] 5.1 Run `go build ./...` — verify compilation
-- [ ] 5.2 Run `go test -tags fts5 ./...` — verify all tests pass
-- [ ] 5.3 Run `kk:test` to verify test coverage for new/changed code
-- [ ] 5.4 Run `kk:document` to update any relevant documentation
-- [ ] 5.5 Run `kk:review-code` with Go profile to review all changes
-- [ ] 5.6 Run `kk:review-spec` to verify implementation matches design.md, implementation.md, and ADR-023
+- [x] 5.1 Run `go build ./...` — verify compilation
+- [x] 5.2 Run `go test -tags fts5 ./...` — verify all tests pass
+- [x] 5.3 Run `kk:test` to verify test coverage for new/changed code
+- [x] 5.4 Run `kk:document` to update any relevant documentation
+- [x] 5.5 Run `kk:review-code` with Go profile to review all changes
+- [x] 5.6 Run `kk:review-spec` to verify implementation matches design.md, implementation.md, and ADR-023

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -21,16 +21,16 @@
 - [x] 1.7 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
 
 ## Task 2: Cap search fallback source listing
-- **Status:** pending
+- **Status:** done
 - **Depends on:** —
 - **Docs:** [implementation.md § Task 2](./implementation.md#task-2-cap-search-fallback-source-listing)
 
 ### Subtasks
-- [ ] 2.1 In `handleSearch()` (`internal/server/tool_search.go` lines 184-199): replace the `ListSources()` + per-source formatting loop with `CountSourcesByKind()` calls for non-excluded kinds
-- [ ] 2.2 Format a single summary line: source count per included kind, plus pointer to `capy_stats` for details (section counts intentionally omitted — source count is sufficient)
-- [ ] 2.3 Update the ephemeral-excluded hint (`tool_search.go:126-131`): add fetched content alongside command output. Change text to mention that ephemeral sources now include both command output and fetched web pages, and add `source: "<label>"` as a recovery path alongside `include_kinds`
-- [ ] 2.4 Write/update test: trigger no-results with multiple indexed sources → assert output contains count summary, does NOT contain individual source labels, still contains updated ephemeral/session hints when applicable
-- [ ] 2.5 Verify: `go test -tags fts5 ./internal/server/...`
+- [x] 2.1 In `handleSearch()` (`internal/server/tool_search.go` lines 184-199): replace the `ListSources()` + per-source formatting loop with `CountSourcesByKind()` calls for non-excluded kinds
+- [x] 2.2 Format a single summary line: source count per included kind, plus pointer to `capy_stats` for details (section counts intentionally omitted — source count is sufficient)
+- [x] 2.3 Update the ephemeral-excluded hint (`tool_search.go:126-131`): add fetched content alongside command output. Change text to mention that ephemeral sources now include both command output and fetched web pages, and add `source: "<label>"` as a recovery path alongside `include_kinds`
+- [x] 2.4 Write/update test: trigger no-results with multiple indexed sources → assert output contains count summary, does NOT contain individual source labels, still contains updated ephemeral/session hints when applicable
+- [x] 2.5 Verify: `go test -tags fts5 ./internal/server/...`
 
 ## Task 3: Update tool descriptions
 - **Status:** pending

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -13,11 +13,12 @@
 
 ### Subtasks
 - [ ] 1.1 Add optional `kind` string parameter (enum: `["durable", "ephemeral"]`) to `toolFetchAndIndex()` in `internal/server/tools.go`
-- [ ] 1.2 In `handleFetchAndIndex()` (`internal/server/tool_fetch.go`): read `kind` from request, default to `store.KindEphemeral`, validate against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values)
-- [ ] 1.3 Replace all four `store.KindDurable` literals at the indexing call sites (lines 132, 138, 141, 145) with the resolved kind variable
-- [ ] 1.4 Update the response text to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for ephemeral follow-up queries
-- [ ] 1.5 Add tests in `tool_fetch_test.go`: no-kind → ephemeral, `kind: "durable"` → durable, `kind: "ephemeral"` → ephemeral, `kind: "invalid"` → error, `kind: "session"` → error
-- [ ] 1.6 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
+- [ ] 1.2 In `handleFetchAndIndex()` (`internal/server/tool_fetch.go`): read and validate `kind` **before** the TTL cache check (before line 52). Default to `store.KindEphemeral`, validate against `"durable"`/`"ephemeral"` only (reject `"session"` and invalid values)
+- [ ] 1.3 Modify the TTL cache check (lines 52-68): after cache hit, compare `meta.Kind` against requested kind. If they differ, bypass cache and proceed with re-fetch+re-index
+- [ ] 1.4 Replace all four `store.KindDurable` literals at the indexing call sites (lines 132, 138, 141, 145) with the resolved kind variable
+- [ ] 1.5 Update the response text to indicate whether content was indexed as durable or ephemeral, and remind about `source:` filter for ephemeral follow-up queries
+- [ ] 1.6 Add tests in `tool_fetch_test.go`: no-kind → ephemeral, `kind: "durable"` → durable, `kind: "ephemeral"` → ephemeral, `kind: "invalid"` → error, `kind: "session"` → error, cache-hit with kind mismatch → cache bypassed and kind updated
+- [ ] 1.7 Verify: `go build ./...` and `go test -tags fts5 ./internal/server/...`
 
 ## Task 2: Cap search fallback source listing
 - **Status:** pending
@@ -39,17 +40,23 @@
 - [ ] 3.1 `toolExecute()` in `tools.go`: remove "MANDATORY" prefix, remove "git queries (git log, git diff)" from examples, reframe as extraction tool with positive/negative guidance
 - [ ] 3.2 `toolBatchExecute()` in `tools.go`: remove "THIS IS THE PRIMARY TOOL", reframe as broad exploration/extraction tool with "NOT for" guidance
 - [ ] 3.3 `toolFetchAndIndex()` in `tools.go`: update description to mention ephemeral default, `kind` parameter, and `source:` filter pattern for follow-up search
-- [ ] 3.4 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
+- [ ] 3.4 `toolSearch()` in `tools.go`: fix stale description — change default from "durable only" to "durable and session", remove "fetched/indexed reference content" parenthetical, update `include_kinds` help text to match actual `effectiveKindFilter` behavior
+- [ ] 3.5 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
 
-## Task 4: Full AGENTS.md rewrite
+## Task 4: Full routing rewrite (AGENTS.md + generated routing blocks)
 - **Status:** pending
 - **Depends on:** Task 1, Task 3
-- **Docs:** [implementation.md § Task 4](./implementation.md#task-4-full-agentsmd-rewrite)
+- **Docs:** [implementation.md § Task 4](./implementation.md#task-4-full-routing-rewrite-agentsmd--generated-routing-blocks)
 
 ### Subtasks
 - [ ] 4.1 Write new `.capy/AGENTS.md` with task-aware routing structure: decision principle, when to use direct tools, when to use capy, blocked commands, source kinds, Read vs capy_execute_file, output constraints, subagent routing, capy commands
-- [ ] 4.2 Verify routing clarity: does the document unambiguously route `git diff` to Bash? Does it route broad `rg` to capy? Does it explain when to pass `kind: "durable"` to fetch?
-- [ ] 4.3 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
+- [ ] 4.2 Rewrite `GenerateRoutingInstructions()` in `internal/platform/routing.go` to produce the same task-aware routing content as AGENTS.md
+- [ ] 4.3 Rewrite `RoutingBlock()` in `internal/hook/routing.go` — replace "MUST use capy", "Primary tool", "DO NOT use Bash >20 lines", "Bash is ONLY for" with task-aware comprehension-vs-extraction guidance
+- [ ] 4.4 Update `BASH_GUIDANCE` constant in `internal/hook/routing.go` — replace "Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only" with task-aware guidance
+- [ ] 4.5 Review `GREP_GUIDANCE` and `READ_GUIDANCE` constants — update if they contradict the new routing principle (READ_GUIDANCE is likely fine as-is)
+- [ ] 4.6 Verify routing clarity: does AGENTS.md unambiguously route `git diff` to Bash? Does `RoutingBlock()` do the same for subagents? Does it explain when to pass `kind: "durable"` to fetch?
+- [ ] 4.7 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
+- [ ] 4.8 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
 
 ## Task 5: Final verification
 - **Status:** pending

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -46,20 +46,20 @@
 - [x] 3.6 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
 
 ## Task 4: Full routing rewrite (AGENTS.md + generated routing blocks)
-- **Status:** pending
+- **Status:** done
 - **Depends on:** Task 1, Task 3
 - **Docs:** [implementation.md § Task 4](./implementation.md#task-4-full-routing-rewrite-agentsmd--generated-routing-blocks)
 
 ### Subtasks
-- [ ] 4.1 Write new `.capy/AGENTS.md` with task-aware routing structure: decision principle, when to use direct tools, when to use capy, blocked commands, source kinds, Read vs capy_execute_file, output constraints, subagent routing, capy commands
-- [ ] 4.2 Rewrite `GenerateRoutingInstructions()` in `internal/platform/routing.go` to produce the same task-aware routing content as AGENTS.md
-- [ ] 4.3 Rewrite `RoutingBlock()` in `internal/hook/routing.go` — replace "MUST use capy", "Primary tool", "DO NOT use Bash >20 lines", "Bash is ONLY for" with task-aware comprehension-vs-extraction guidance
-- [ ] 4.4 Update `BASH_GUIDANCE` constant in `internal/hook/routing.go` — replace "Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only" with task-aware guidance
-- [ ] 4.5 Review `GREP_GUIDANCE` and `READ_GUIDANCE` constants — update if they contradict the new routing principle (READ_GUIDANCE is likely fine as-is)
-- [ ] 4.6 Review build-tool redirect in `internal/hook/pretooluse.go:111-116` — `isBuildTool()` hard-redirects Gradle/Maven to `capy_execute`, but build output is sequential (test results, compilation errors) where order matters. Either remove the redirect, soften it to guidance, or add an exception for build commands that produce comprehension-required output
-- [ ] 4.7 Verify routing clarity: does AGENTS.md unambiguously route `git diff` to Bash? Does `RoutingBlock()` do the same for subagents? Does it explain when to pass `kind: "durable"` to fetch?
-- [ ] 4.8 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
-- [ ] 4.9 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
+- [x] 4.1 Write new `.capy/AGENTS.md` with task-aware routing structure: decision principle, when to use direct tools, when to use capy, blocked commands, source kinds, Read vs capy_execute_file, output constraints, subagent routing, capy commands
+- [x] 4.2 Rewrite `GenerateRoutingInstructions()` in `internal/platform/routing.go` to produce the same task-aware routing content as AGENTS.md
+- [x] 4.3 Rewrite `RoutingBlock()` in `internal/hook/routing.go` — replace "MUST use capy", "Primary tool", "DO NOT use Bash >20 lines", "Bash is ONLY for" with task-aware comprehension-vs-extraction guidance
+- [x] 4.4 Update `BASH_GUIDANCE` constant in `internal/hook/routing.go` — replace "Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only" with task-aware guidance
+- [x] 4.5 Review `GREP_GUIDANCE` and `READ_GUIDANCE` constants — update if they contradict the new routing principle (READ_GUIDANCE is likely fine as-is)
+- [x] 4.6 Review build-tool redirect in `internal/hook/pretooluse.go:111-116` — removed hard redirect; build tools now receive BASH_GUIDANCE instead, consistent with comprehension-vs-extraction principle (build output is sequential comprehension content)
+- [x] 4.7 Verify routing clarity: does AGENTS.md unambiguously route `git diff` to Bash? Does `RoutingBlock()` do the same for subagents? Does it explain when to pass `kind: "durable"` to fetch?
+- [x] 4.8 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
+- [x] 4.9 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
 
 ## Task 5: Final verification
 - **Status:** pending

--- a/docs/wip/issue-44-over-preservation-routing/tasks.md
+++ b/docs/wip/issue-44-over-preservation-routing/tasks.md
@@ -27,9 +27,10 @@
 
 ### Subtasks
 - [ ] 2.1 In `handleSearch()` (`internal/server/tool_search.go` lines 184-199): replace the `ListSources()` + per-source formatting loop with `CountSourcesByKind()` calls for non-excluded kinds
-- [ ] 2.2 Format a single summary line: count of sources and sections for each included kind, plus pointer to `capy_stats` for details
-- [ ] 2.3 Write/update test: trigger no-results with multiple indexed sources → assert output contains count summary, does NOT contain individual source labels, still contains ephemeral/session hints when applicable
-- [ ] 2.4 Verify: `go test -tags fts5 ./internal/server/...`
+- [ ] 2.2 Format a single summary line: source count per included kind, plus pointer to `capy_stats` for details (section counts intentionally omitted — source count is sufficient)
+- [ ] 2.3 Update the ephemeral-excluded hint (`tool_search.go:126-131`): add fetched content alongside command output. Change text to mention that ephemeral sources now include both command output and fetched web pages, and add `source: "<label>"` as a recovery path alongside `include_kinds`
+- [ ] 2.4 Write/update test: trigger no-results with multiple indexed sources → assert output contains count summary, does NOT contain individual source labels, still contains updated ephemeral/session hints when applicable
+- [ ] 2.5 Verify: `go test -tags fts5 ./internal/server/...`
 
 ## Task 3: Update tool descriptions
 - **Status:** pending
@@ -41,7 +42,8 @@
 - [ ] 3.2 `toolBatchExecute()` in `tools.go`: remove "THIS IS THE PRIMARY TOOL", reframe as broad exploration/extraction tool with "NOT for" guidance
 - [ ] 3.3 `toolFetchAndIndex()` in `tools.go`: update description to mention ephemeral default, `kind` parameter, and `source:` filter pattern for follow-up search
 - [ ] 3.4 `toolSearch()` in `tools.go`: fix stale description — change default from "durable only" to "durable and session", remove "fetched/indexed reference content" parenthetical, update `include_kinds` help text to match actual `effectiveKindFilter` behavior
-- [ ] 3.5 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
+- [ ] 3.5 `toolExecuteFile()` in `tools.go`: soften "PREFER THIS OVER Read/cat" to align with comprehension-vs-extraction principle. Reframe: "for large files (10k+ lines) where you only need derived answers. Read is correct when you need to understand or edit the file."
+- [ ] 3.6 Verify: `go build ./...`, start MCP server, call `tools/list`, inspect descriptions
 
 ## Task 4: Full routing rewrite (AGENTS.md + generated routing blocks)
 - **Status:** pending
@@ -54,9 +56,10 @@
 - [ ] 4.3 Rewrite `RoutingBlock()` in `internal/hook/routing.go` — replace "MUST use capy", "Primary tool", "DO NOT use Bash >20 lines", "Bash is ONLY for" with task-aware comprehension-vs-extraction guidance
 - [ ] 4.4 Update `BASH_GUIDANCE` constant in `internal/hook/routing.go` — replace "Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only" with task-aware guidance
 - [ ] 4.5 Review `GREP_GUIDANCE` and `READ_GUIDANCE` constants — update if they contradict the new routing principle (READ_GUIDANCE is likely fine as-is)
-- [ ] 4.6 Verify routing clarity: does AGENTS.md unambiguously route `git diff` to Bash? Does `RoutingBlock()` do the same for subagents? Does it explain when to pass `kind: "durable"` to fetch?
-- [ ] 4.7 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
-- [ ] 4.8 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
+- [ ] 4.6 Review build-tool redirect in `internal/hook/pretooluse.go:111-116` — `isBuildTool()` hard-redirects Gradle/Maven to `capy_execute`, but build output is sequential (test results, compilation errors) where order matters. Either remove the redirect, soften it to guidance, or add an exception for build commands that produce comprehension-required output
+- [ ] 4.7 Verify routing clarity: does AGENTS.md unambiguously route `git diff` to Bash? Does `RoutingBlock()` do the same for subagents? Does it explain when to pass `kind: "durable"` to fetch?
+- [ ] 4.8 Verify no orphaned references: check if other docs reference AGENTS.md sections that were renamed or removed
+- [ ] 4.9 Run tests: `go test -tags fts5 ./internal/hook/... ./internal/platform/...`
 
 ## Task 5: Final verification
 - **Status:** pending

--- a/internal/hook/helpers.go
+++ b/internal/hook/helpers.go
@@ -75,14 +75,6 @@ func hasInlineHTTP(cmd string) bool {
 	return false
 }
 
-// buildToolRe matches build tools: gradle, gradlew, mvn, mvnw.
-var buildToolRe = regexp.MustCompile(`(?i)(^|\s|&&|\||\;)(\.\/gradlew|gradlew|gradle|\.\/mvnw|mvnw|mvn)\s`)
-
-// isBuildTool returns true if the (stripped) command invokes a build tool.
-func isBuildTool(stripped string) bool {
-	return buildToolRe.MatchString(stripped)
-}
-
 // splitChainedCommands splits a shell command on &&, ||, ;, and | operators,
 // respecting single-quoted, double-quoted, and backtick-quoted strings.
 func splitChainedCommands(cmd string) []string {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -235,19 +235,16 @@ func TestPreToolUse_FetchBlocked(t *testing.T) {
 	assert.Equal(t, "modify", result["action"])
 }
 
-func TestPreToolUse_BuildToolBlocked(t *testing.T) {
-	ResetGuidanceThrottle()
+func TestPreToolUse_BuildToolGuidance(t *testing.T) {
 	a := &testAdapter{}
 	for _, cmd := range []string{"./gradlew build", "gradle test", "mvn clean install", "./mvnw package"} {
-		ResetGuidanceThrottle()
 		input := makeInput("Bash", map[string]any{"command": cmd})
 		output, err := handlePreToolUse(input, a, nil, "")
 		require.NoError(t, err)
-		require.NotNil(t, output, "expected modify for: %s", cmd)
+		require.NotNil(t, output, "expected guidance for: %s", cmd)
 		result := parseResult(t, output)
-		assert.Equal(t, "modify", result["action"], "expected modify for: %s", cmd)
-		updated := result["updatedInput"].(map[string]any)
-		assert.Contains(t, updated["command"], "sandbox", "for: %s", cmd)
+		assert.Equal(t, "context", result["action"], "expected guidance for: %s", cmd)
+		assert.Contains(t, result["additionalContext"], "context_guidance", "for: %s", cmd)
 	}
 }
 
@@ -524,15 +521,6 @@ func TestHasInlineHTTP(t *testing.T) {
 	assert.True(t, hasInlineHTTP(`requests.get('https://api.com')`))
 	assert.True(t, hasInlineHTTP(`http.get('http://localhost:3000')`))
 	assert.False(t, hasInlineHTTP("echo hello world"))
-}
-
-func TestIsBuildTool(t *testing.T) {
-	assert.True(t, isBuildTool("./gradlew build"))
-	assert.True(t, isBuildTool("gradle test"))
-	assert.True(t, isBuildTool("mvn clean install"))
-	assert.True(t, isBuildTool("./mvnw package"))
-	assert.False(t, isBuildTool("go build ./..."))
-	assert.False(t, isBuildTool("npm run build"))
 }
 
 func TestIsCapyTool(t *testing.T) {

--- a/internal/hook/integration_test.go
+++ b/internal/hook/integration_test.go
@@ -262,8 +262,7 @@ func TestHookIntegration_GeminiAlias_CurlBlocked(t *testing.T) {
 
 // ─── Build tool routing ────────────────────────────────────────────────────────
 
-func TestHookIntegration_GradleBuild_Redirected(t *testing.T) {
-	ResetGuidanceThrottle()
+func TestHookIntegration_GradleBuild_Guidance(t *testing.T) {
 	a := ccAdapter()
 	input := ccInput("Bash", map[string]any{"command": "./gradlew build"})
 	output, err := handlePreToolUse(input, a, nil, "")
@@ -271,9 +270,9 @@ func TestHookIntegration_GradleBuild_Redirected(t *testing.T) {
 	require.NotNil(t, output)
 
 	hso := ccParse(t, output)
-	assert.Equal(t, "allow", hso["permissionDecision"])
-	updated := hso["updatedInput"].(map[string]any)
-	assert.Contains(t, updated["command"], "sandbox")
+	ctx, ok := hso["additionalContext"].(string)
+	require.True(t, ok, "expected additionalContext for build tool guidance")
+	assert.Contains(t, ctx, "context_guidance")
 }
 
 // ─── Session start ─────────────────────────────────────────────────────────────

--- a/internal/hook/pretooluse.go
+++ b/internal/hook/pretooluse.go
@@ -108,13 +108,6 @@ func routeBash(command string, policies []security.SecurityPolicy, a adapter.Hoo
 		})
 	}
 
-	// Build tools (gradle, maven) → redirect to sandbox
-	if isBuildTool(stripped) {
-		return a.FormatModify(map[string]any{
-			"command": `echo "capy: Build tool redirected to sandbox. Use capy_execute(language: \"shell\", code: \"...\") to run this command. Do NOT retry with Bash."`,
-		})
-	}
-
 	// Allow, but inject routing nudge (once per session)
 	return guidanceOnce("bash", BASH_GUIDANCE, a, projectDir, sessionID)
 }

--- a/internal/hook/routing.go
+++ b/internal/hook/routing.go
@@ -1,32 +1,38 @@
 package hook
 
 // RoutingBlock returns the XML routing instructions injected into subagent
-// prompts and session start events. Guides the LLM to use capy MCP tools
-// instead of raw Bash/Read/WebFetch.
+// prompts and session start events. Guides the LLM on when to use capy MCP
+// tools vs direct tools based on comprehension-vs-extraction needs.
 func RoutingBlock() string {
 	return `<context_window_protection>
-  <priority_instructions>
-    Raw tool output floods your context window. You MUST use capy
-    MCP tools to keep raw data in the sandbox.
-  </priority_instructions>
+  <routing_principle>
+    Choose tools based on what you need from the output:
+    - Comprehension (understand full content) → Bash, Read
+    - Extraction (specific facts from large output) → capy tools
+  </routing_principle>
 
-  <tool_selection_hierarchy>
-    1. GATHER: capy_batch_execute(commands, queries)
-       - Primary tool for research. Runs all commands, auto-indexes, and searches.
-       - ONE call replaces many individual steps.
-    2. FOLLOW-UP: capy_search(queries: ["q1", "q2", ...])
-       - Use for all follow-up questions. ONE call, many queries.
-    3. PROCESSING: capy_execute(language, code) | capy_execute_file(path, language, code)
-       - Use for API calls, log analysis, and data processing.
-  </tool_selection_hierarchy>
+  <direct_tools>
+    Use Bash/Read for:
+    - Git commands (diffs, logs, status) — always Bash
+    - Small-output commands (less than ~50 lines)
+    - Files to comprehend or edit (Read)
+    - Sequential/ordered content (test output, build logs)
+    - Instruction files, checklists, configs (Read whole)
+  </direct_tools>
 
-  <forbidden_actions>
-    - DO NOT use Bash for commands producing >20 lines of output.
-    - For large files (10k+ lines), prefer execute_file when you only need derived answers (counts, patterns). Read IS correct for any file you need to understand, follow as instructions, or edit.
-    - DO NOT use capy_index on instruction files (skills, checklists, configs, plugin files). Read them directly — they must be internalized whole, not searched as fragments.
-    - DO NOT use WebFetch (use capy_fetch_and_index instead).
-    - Bash is ONLY for git/mkdir/rm/mv/navigation.
-  </forbidden_actions>
+  <capy_tools>
+    Use capy for:
+    - capy_batch_execute: broad exploration, multiple commands + queries in ONE call
+    - capy_execute / capy_execute_file: large-output extraction (hundreds+ lines)
+    - capy_fetch_and_index: web content (default ephemeral; kind: "durable" for reference docs)
+    - capy_search: query indexed content (batch questions as array)
+  </capy_tools>
+
+  <blocked>
+    - curl/wget in Bash → use capy_fetch_and_index or capy_execute
+    - Inline HTTP in Bash → use capy_execute
+    - WebFetch → use capy_fetch_and_index
+  </blocked>
 
   <output_constraints>
     <word_limit>Keep your final response under 500 words.</word_limit>
@@ -66,19 +72,18 @@ const READ_GUIDANCE = `<context_guidance>
 // GREP_GUIDANCE is the one-time advisory shown when Grep is used.
 const GREP_GUIDANCE = `<context_guidance>
   <tip>
-    This operation may flood your context window. To stay efficient:
-    - Use capy_execute(language: "shell", code: "...") to run searches in the sandbox.
-    - Only your final printed summary will enter the context.
+    Grep results can be large. If you need all matches for comprehension, this is fine.
+    For extraction from large result sets, use capy_execute(language: "shell", code: "grep ...")
+    to run in sandbox — only your printed summary enters context.
   </tip>
 </context_guidance>`
 
 // BASH_GUIDANCE is the one-time advisory shown when Bash is used (and not blocked).
 const BASH_GUIDANCE = `<context_guidance>
   <tip>
-    This Bash command may produce large output. To stay efficient:
-    - Use capy_batch_execute(commands, queries) for multiple commands
-    - Use capy_execute(language: "shell", code: "...") to run in sandbox
-    - Only your final printed summary will enter the context.
-    - Bash is best for: git, mkdir, rm, mv, navigation, and short-output commands only.
+    This Bash command may produce large output. Consider:
+    - If you need to comprehend the full output (diffs, test results, logs): Bash is correct.
+    - If you only need extracted facts from large output: use capy_execute or capy_batch_execute.
+    - For multiple commands + search in ONE call: capy_batch_execute.
   </tip>
 </context_guidance>`

--- a/internal/hook/routing.go
+++ b/internal/hook/routing.go
@@ -40,13 +40,6 @@ func RoutingBlock() string {
       Write artifacts (code, configs, PRDs) to FILES. NEVER return them as inline text.
       Return only: file path + 1-line description.
     </artifact_policy>
-    <response_format>
-      Your response must be a concise summary:
-      - Actions taken (2-3 bullets)
-      - File paths created/modified
-      - Knowledge base source labels (so parent can search)
-      - Key findings
-    </response_format>
   </output_constraints>
 
   <capy_commands>

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -14,13 +14,36 @@ var CapyToolNames = []string{
 }
 
 // GenerateRoutingInstructions returns the CLAUDE.md routing block that instructs
-// the LLM to use capy MCP tools instead of raw Bash/Read/WebFetch.
+// the LLM on when to use capy MCP tools vs direct tools (Bash/Read).
 func GenerateRoutingInstructions() string {
-	return `# capy — MANDATORY routing rules
+	return `# capy — context-window routing
 
-You have capy MCP tools available. These rules are NOT optional — they protect your context window from flooding. A single unrouted command can dump 56 KB into context and waste the entire session.
+Capy MCP tools protect your context window by keeping raw tool output in sandboxed subprocesses and indexing it for on-demand search.
 
-## BLOCKED commands — do NOT attempt these
+## Decision principle
+
+Choose the tool based on what you need from the output:
+
+- **Comprehension** (understand the full content) → direct tools (Bash, Read)
+- **Extraction** (specific facts from large output) → capy tools
+
+## When to use direct tools (Bash / Read)
+
+- **Git commands:** diffs, logs, status, branch — always Bash. Diffs are comprehension content; BM25 fragments destroy review quality.
+- **Small-output commands (<~50 lines):** ls, wc, file, git status — Bash directly. Sandbox overhead exceeds savings.
+- **Files to comprehend or edit:** Read tool. Required before Edit.
+- **Sequential/ordered content:** test output, build logs where order matters — Bash or Read.
+- **Instruction files, checklists, configs:** Read and internalize whole. BM25 returns ranked fragments, destroying structural relationships.
+
+## When to use capy tools
+
+- **` + "`capy_batch_execute`" + `:** Broad exploration — multiple commands + queries in one call. Example: initial repo scan with ` + "`rg --files`" + ` + symbol searches.
+- **` + "`capy_execute`" + ` / ` + "`capy_execute_file`" + `:** Single command or file producing hundreds+ lines where you only need extracted facts. API calls, log analysis, data processing.
+- **` + "`capy_fetch_and_index`" + `:** Fetch web content. Default ephemeral (24h TTL, excluded from default search). Pass ` + "`kind: \"durable\"`" + ` for reference docs. Use ` + "`source: \"<label>\"`" + ` for follow-up search.
+- **` + "`capy_index`" + `:** Persist curated knowledge durably. Content you explicitly want searchable across sessions.
+- **` + "`capy_search`" + `:** Query indexed content. Batch all questions as array. Default excludes ephemeral — use ` + "`include_kinds`" + ` or ` + "`source:`" + ` to include.
+
+## Blocked commands — enforced by hooks
 
 ### curl / wget — BLOCKED
 Any Bash command containing ` + "`curl`" + ` or ` + "`wget`" + ` is intercepted and replaced with an error message. Do NOT retry.
@@ -38,15 +61,23 @@ WebFetch calls are denied entirely. The URL is extracted and you are told to use
 Instead use:
 - ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + ` to query the indexed content
 
-## REDIRECTED tools — use sandbox equivalents
+## Source kinds
 
-### Bash (>20 lines output)
-Bash is ONLY for: ` + "`git`" + `, ` + "`mkdir`" + `, ` + "`rm`" + `, ` + "`mv`" + `, ` + "`cd`" + `, ` + "`ls`" + `, ` + "`npm install`" + `, ` + "`pip install`" + `, and other short-output commands.
-For everything else, use:
-- ` + "`capy_batch_execute(commands, queries)`" + ` — run multiple commands + search in ONE call
-- ` + "`capy_execute(language: \"shell\", code: \"...\")`" + ` — run in sandbox, only stdout enters context
+Every indexed entry has a **kind** that controls its lifecycle and search visibility:
 
-### Read vs capy_execute_file / capy_index
+| Kind | What produces it | Retention | Included by default in search? |
+|------|-----------------|-----------|-------------------------------|
+| ` + "`durable`" + ` | ` + "`capy_index`" + `, ` + "`capy_fetch_and_index(kind: \"durable\")`" + ` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
+| ` + "`ephemeral`" + ` | ` + "`capy_execute`" + `, ` + "`capy_execute_file`" + `, ` + "`capy_batch_execute`" + `, ` + "`capy_fetch_and_index`" + ` (default) | Strict TTL — swept after expiry | No |
+| ` + "`session`" + ` | ` + "`capy sweep`" + ` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+
+**Querying non-default kinds:** pass ` + "`include_kinds`" + ` to ` + "`capy_search`" + `:
+- ` + "`include_kinds: [\"durable\", \"ephemeral\"]`" + ` — recover output from earlier commands in this session
+- ` + "`include_kinds: [\"durable\", \"session\"]`" + ` — search past conversation transcripts
+- ` + "`include_kinds: [\"durable\", \"ephemeral\", \"session\"]`" + ` — search everything
+- Or use ` + "`source: \"<label>\"`" + ` to bypass kind filtering entirely (matches any kind)
+
+## Read vs capy_execute_file
 
 **Default to ` + "`Read`" + `.** It's cheap for normal-sized files, shows you actual content (not just patterns you knew to grep for), and is required if an Edit follows. Use ` + "`offset`" + `/` + "`limit`" + ` to scope large files.
 
@@ -64,42 +95,15 @@ For everything else, use:
 
 **Rule of thumb:** capy saves context only when raw data would otherwise flood context and you don't need the full content. If the document is meant to be followed as instructions, applied as a checklist, or read for comprehension — use ` + "`Read`" + `. Indexing turns a coherent document into a bag of fragments.
 
-### Grep (large results)
-Grep results can flood context. Use ` + "`capy_execute(language: \"shell\", code: \"grep ...\")`" + ` to run searches in sandbox. Only your printed summary enters context.
-
-## Tool selection hierarchy
-
-1. **GATHER**: ` + "`capy_batch_execute(commands, queries)`" + ` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls.
-2. **FOLLOW-UP**: ` + "`capy_search(queries: [\"q1\", \"q2\", ...])`" + ` — Query indexed content. Pass ALL questions as array in ONE call.
-3. **PROCESSING**: ` + "`capy_execute(language, code)`" + ` | ` + "`capy_execute_file(path, language, code)`" + ` — Sandbox execution. Only stdout enters context.
-4. **WEB**: ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + ` — Fetch, chunk, index, query. Raw HTML never enters context.
-5. **INDEX**: ` + "`capy_index(content, source)`" + ` — Store content in FTS5 knowledge base for later search.
-
-## Source kinds
-
-Every indexed entry has a **kind** that controls its lifecycle and search visibility:
-
-| Kind | What produces it | Retention | Included by default in search? |
-|------|-----------------|-----------|-------------------------------|
-| ` + "`durable`" + ` | ` + "`capy_index`" + `, ` + "`capy_fetch_and_index`" + ` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
-| ` + "`ephemeral`" + ` | ` + "`capy_execute`" + `, ` + "`capy_execute_file`" + `, ` + "`capy_batch_execute`" + ` (auto-indexed output) | Strict TTL — swept after expiry | No |
-| ` + "`session`" + ` | ` + "`capy sweep`" + ` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
-
-**Querying non-default kinds:** pass ` + "`include_kinds`" + ` to ` + "`capy_search`" + `:
-- ` + "`include_kinds: [\"durable\", \"ephemeral\"]`" + ` — recover output from earlier commands in this session
-- ` + "`include_kinds: [\"durable\", \"session\"]`" + ` — search past conversation transcripts
-- ` + "`include_kinds: [\"durable\", \"ephemeral\", \"session\"]`" + ` — search everything
-- Or use ` + "`source: \"<label>\"`" + ` to bypass kind filtering entirely (matches any kind)
-
-## Subagent routing
-
-When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.
-
 ## Output constraints
 
 - Keep responses under 500 words.
 - Write artifacts (code, configs, PRDs) to FILES — never return them as inline text. Return only: file path + 1-line description.
 - When indexing content, use descriptive source labels so others can ` + "`capy_search(source: \"label\")`" + ` later.
+
+## Subagent routing
+
+When spawning subagents (Agent/Task tool), the routing block is automatically injected into their prompt. Bash-type subagents are upgraded to general-purpose so they have access to MCP tools. You do NOT need to manually instruct subagents about capy.
 
 ## capy commands
 

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -69,11 +69,10 @@ Every indexed entry has a **kind** that controls its lifecycle and search visibi
 |------|-----------------|-----------|-------------------------------|
 | ` + "`durable`" + ` | ` + "`capy_index`" + `, ` + "`capy_fetch_and_index(kind: \"durable\")`" + ` | Retention-score tiers (hot → warm → cold → evictable) | Yes |
 | ` + "`ephemeral`" + ` | ` + "`capy_execute`" + `, ` + "`capy_execute_file`" + `, ` + "`capy_batch_execute`" + `, ` + "`capy_fetch_and_index`" + ` (default) | Strict TTL — swept after expiry | No |
-| ` + "`session`" + ` | ` + "`capy sweep`" + ` (indexes past conversation transcripts) | Strict TTL — swept after expiry | No |
+| ` + "`session`" + ` | ` + "`capy sweep`" + ` (indexes past conversation transcripts) | Strict TTL — swept after expiry | Yes |
 
 **Querying non-default kinds:** pass ` + "`include_kinds`" + ` to ` + "`capy_search`" + `:
 - ` + "`include_kinds: [\"durable\", \"ephemeral\"]`" + ` — recover output from earlier commands in this session
-- ` + "`include_kinds: [\"durable\", \"session\"]`" + ` — search past conversation transcripts
 - ` + "`include_kinds: [\"durable\", \"ephemeral\", \"session\"]`" + ` — search everything
 - Or use ` + "`source: \"<label>\"`" + ` to bypass kind filtering entirely (matches any kind)
 

--- a/internal/platform/routing_test.go
+++ b/internal/platform/routing_test.go
@@ -26,9 +26,11 @@ func TestGenerateRoutingInstructions(t *testing.T) {
 	}
 
 	// Must contain key sections
-	assert.Contains(t, instructions, "BLOCKED commands")
-	assert.Contains(t, instructions, "REDIRECTED tools")
-	assert.Contains(t, instructions, "Tool selection hierarchy")
+	assert.Contains(t, instructions, "Decision principle")
+	assert.Contains(t, instructions, "When to use direct tools")
+	assert.Contains(t, instructions, "When to use capy tools")
+	assert.Contains(t, instructions, "Blocked commands")
+	assert.Contains(t, instructions, "Source kinds")
 	assert.Contains(t, instructions, "Subagent routing")
 	assert.Contains(t, instructions, "Output constraints")
 	assert.Contains(t, instructions, "capy commands")

--- a/internal/platform/setup.go
+++ b/internal/platform/setup.go
@@ -562,8 +562,14 @@ const routingImportRef = "@.capy/AGENTS.md"
 // oldRoutingImportRef is the previous import path, used for migration.
 const oldRoutingImportRef = "@.claude/capy/CLAUDE.md"
 
+// routingImportHeading is the current heading for the routing import block.
+const routingImportHeading = "# capy — context-window routing"
+
+// oldRoutingImportHeading is the previous heading, used for migration.
+const oldRoutingImportHeading = "# capy — MANDATORY routing rules"
+
 // routingImportBlock is the full block appended to root CLAUDE.md to import capy routing.
-const routingImportBlock = "# capy — MANDATORY routing rules\n\n" + routingImportRef + "\n"
+const routingImportBlock = routingImportHeading + "\n\n" + routingImportRef + "\n"
 
 // writeAgentsFile writes routing instructions to .capy/AGENTS.md.
 func writeAgentsFile(projectDir string) error {
@@ -582,27 +588,41 @@ func ensureClaudeMDImport(claudeMDPath string) error {
 
 	text := string(content)
 
-	// Already has the current import → nothing to do
+	// Already has the current import → migrate heading if stale
 	if strings.Contains(text, routingImportRef) {
+		if strings.Contains(text, oldRoutingImportHeading) {
+			text = strings.Replace(text, oldRoutingImportHeading, routingImportHeading, 1)
+			return os.WriteFile(claudeMDPath, []byte(text), 0o644)
+		}
 		return nil
 	}
 
-	// Old import path (.claude/capy/CLAUDE.md) → replace with new path
+	// Old import path (.claude/capy/CLAUDE.md) → replace with new path and heading
 	if strings.Contains(text, oldRoutingImportRef) {
 		text = strings.ReplaceAll(text, oldRoutingImportRef, routingImportRef)
+		if strings.Contains(text, oldRoutingImportHeading) {
+			text = strings.Replace(text, oldRoutingImportHeading, routingImportHeading, 1)
+		}
 		return os.WriteFile(claudeMDPath, []byte(text), 0o644)
 	}
 
-	// Old inline routing block present → replace with import.
-	// Uses marker-based detection so migration works even when
-	// GenerateRoutingInstructions() output changed between versions.
-	const startMarker = "# capy — MANDATORY routing rules"
-	if startIdx := strings.Index(text, startMarker); startIdx >= 0 {
-		rest := text[startIdx+len(startMarker):]
+	// Inline routing block present → replace with import.
+	// Check both old and current headings so migration works across versions.
+	markerIdx := -1
+	markerLen := 0
+	if idx := strings.Index(text, oldRoutingImportHeading); idx >= 0 {
+		markerIdx = idx
+		markerLen = len(oldRoutingImportHeading)
+	} else if idx := strings.Index(text, routingImportHeading); idx >= 0 {
+		markerIdx = idx
+		markerLen = len(routingImportHeading)
+	}
+	if markerIdx >= 0 {
+		rest := text[markerIdx+markerLen:]
 		if endIdx := strings.Index(rest, "\n# "); endIdx >= 0 {
-			text = text[:startIdx] + routingImportBlock + rest[endIdx+1:]
+			text = text[:markerIdx] + routingImportBlock + rest[endIdx+1:]
 		} else {
-			text = text[:startIdx] + routingImportBlock
+			text = text[:markerIdx] + routingImportBlock
 		}
 		return os.WriteFile(claudeMDPath, []byte(text), 0o644)
 	}

--- a/internal/platform/setup_test.go
+++ b/internal/platform/setup_test.go
@@ -87,7 +87,7 @@ func TestSetupClaudeCode(t *testing.T) {
 	assert.Contains(t, string(agentsMD), "capy_batch_execute")
 	assert.Contains(t, string(agentsMD), "capy_search")
 	assert.Contains(t, string(agentsMD), "capy_execute")
-	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy — context-window routing")
 
 	// Verify root CLAUDE.md has import, not inline routing
 	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
@@ -142,7 +142,7 @@ func TestSetupIdempotent(t *testing.T) {
 	// .capy/AGENTS.md should have routing instructions
 	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Equal(t, 1, strings.Count(string(agentsMD), "capy — MANDATORY routing rules"),
+	assert.Equal(t, 1, strings.Count(string(agentsMD), "capy — context-window routing"),
 		"should not duplicate routing instructions in AGENTS.md")
 
 	// .gitignore should not have duplicate entries
@@ -320,7 +320,7 @@ func TestSetupMigratesInlineRouting(t *testing.T) {
 	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
 	assert.Contains(t, string(agentsMD), "capy_batch_execute")
-	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy — context-window routing")
 }
 
 func TestSetupMigratesStaleInlineRouting(t *testing.T) {
@@ -413,6 +413,34 @@ func TestSetupMigratesInlineRouting_Idempotent(t *testing.T) {
 	assert.Contains(t, content, "# Footer")
 }
 
+func TestSetupMigratesStaleHeading(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := "/usr/local/bin/capy"
+
+	// Simulate a CLAUDE.md that already has the current import ref but
+	// still uses the old heading (user who ran setup with a previous binary).
+	oldContent := "# My Project\n\n# capy — MANDATORY routing rules\n\n@.capy/AGENTS.md\n\n# Footer\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(oldContent), 0o644))
+
+	require.NoError(t, SetupClaudeCode(binaryPath, dir, SettingsProject))
+
+	claudeMD, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	require.NoError(t, err)
+	content := string(claudeMD)
+
+	// Heading should be updated
+	assert.Contains(t, content, "# capy — context-window routing")
+	assert.NotContains(t, content, "# capy — MANDATORY routing rules")
+
+	// Import ref should not be duplicated
+	assert.Equal(t, 1, strings.Count(content, "@.capy/AGENTS.md"),
+		"should not duplicate import ref during heading migration")
+
+	// Surrounding content preserved
+	assert.Contains(t, content, "# My Project")
+	assert.Contains(t, content, "# Footer")
+}
+
 func TestSetupCodex(t *testing.T) {
 	dir := t.TempDir()
 	binaryPath := "/usr/local/bin/capy"
@@ -439,7 +467,7 @@ func TestSetupCodex(t *testing.T) {
 	// Verify .capy/AGENTS.md has routing instructions
 	agentsMD, err := os.ReadFile(filepath.Join(dir, agentsRelPath))
 	require.NoError(t, err)
-	assert.Contains(t, string(agentsMD), "capy — MANDATORY routing rules")
+	assert.Contains(t, string(agentsMD), "capy — context-window routing")
 	assert.Contains(t, string(agentsMD), "capy_batch_execute")
 
 	// Verify .codex/config.toml has MCP server with env_vars

--- a/internal/server/tool_fetch.go
+++ b/internal/server/tool_fetch.go
@@ -71,9 +71,13 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 		}
 		if err == nil && meta != nil && time.Since(meta.IndexedAt) < ttl && meta.Kind == kind {
 			s.stats.AddCacheHit(int64(meta.ChunkCount) * 1600) // ~1.6KB per chunk estimate
+			kindInfo := string(meta.Kind)
+			if meta.Kind == store.KindEphemeral {
+				kindInfo += ", excluded from default search"
+			}
 			text := fmt.Sprintf(
 				"**Cache hit** — source %q was indexed %s (%d chunks, %s).\nConfigured TTL: %dh. Use `force: true` to re-fetch.\nUse search(queries: [...], source: %q) for lookups.",
-				meta.Label, formatAge(time.Since(meta.IndexedAt)), meta.ChunkCount, meta.Kind,
+				meta.Label, formatAge(time.Since(meta.IndexedAt)), meta.ChunkCount, kindInfo,
 				s.config.Store.Cache.FetchTTLHours, meta.Label,
 			)
 			return s.trackToolResponse("capy_fetch_and_index", textResult(text)), nil

--- a/internal/server/tool_fetch.go
+++ b/internal/server/tool_fetch.go
@@ -34,9 +34,21 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 	url := req.GetString("url", "")
 	source := req.GetString("source", "")
 	force, _ := req.GetArguments()["force"].(bool)
+	kindStr := req.GetString("kind", "")
 
 	if url == "" {
 		return errorResult("Missing required parameter: url"), nil
+	}
+
+	// Validate at the boundary before cache check and network fetch — gives a clean
+	// error cheaply. The store also validates at write time as defense-in-depth.
+	kind := store.KindEphemeral
+	if kindStr != "" {
+		k := store.SourceKind(kindStr)
+		if k != store.KindDurable && k != store.KindEphemeral {
+			return errorResult(fmt.Sprintf("Invalid kind %q: accepted values are \"durable\" and \"ephemeral\"", kindStr)), nil
+		}
+		kind = k
 	}
 
 	// SSRF protection: block requests to local/private networks
@@ -57,11 +69,11 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 		if err != nil {
 			slog.Warn("cache check failed, proceeding with fetch", "label", label, "error", err)
 		}
-		if err == nil && meta != nil && time.Since(meta.IndexedAt) < ttl {
+		if err == nil && meta != nil && time.Since(meta.IndexedAt) < ttl && meta.Kind == kind {
 			s.stats.AddCacheHit(int64(meta.ChunkCount) * 1600) // ~1.6KB per chunk estimate
 			text := fmt.Sprintf(
-				"**Cache hit** — source %q was indexed %s (%d chunks).\nConfigured TTL: %dh. Use `force: true` to re-fetch.\nUse search(queries: [...], source: %q) for lookups.",
-				meta.Label, formatAge(time.Since(meta.IndexedAt)), meta.ChunkCount,
+				"**Cache hit** — source %q was indexed %s (%d chunks, %s).\nConfigured TTL: %dh. Use `force: true` to re-fetch.\nUse search(queries: [...], source: %q) for lookups.",
+				meta.Label, formatAge(time.Since(meta.IndexedAt)), meta.ChunkCount, meta.Kind,
 				s.config.Store.Cache.FetchTTLHours, meta.Label,
 			)
 			return s.trackToolResponse("capy_fetch_and_index", textResult(text)), nil
@@ -129,20 +141,19 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 
 	switch {
 	case strings.Contains(contentType, "application/json") || strings.Contains(contentType, "+json"):
-		indexed, err = st.IndexJSON(content, source, store.KindDurable)
+		indexed, err = st.IndexJSON(content, source, kind)
 
 	case strings.Contains(contentType, "text/html") || strings.Contains(contentType, "application/xhtml"):
 		md, convErr := convertHTMLToMarkdown(content)
 		if convErr != nil {
-			// Fall back to plain text if conversion fails
-			indexed, err = st.IndexPlainText(content, source, store.KindDurable)
+			indexed, err = st.IndexPlainText(content, source, kind)
 		} else {
 			content = md
-			indexed, err = st.Index(md, source, "", store.KindDurable)
+			indexed, err = st.Index(md, source, "", kind)
 		}
 
 	default:
-		indexed, err = st.IndexPlainText(content, source, store.KindDurable)
+		indexed, err = st.IndexPlainText(content, source, kind)
 	}
 
 	if err != nil {
@@ -156,9 +167,17 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 	}
 	totalKB := fmt.Sprintf("%.1f", float64(len(content))/1024)
 
+	kindNote := fmt.Sprintf("Indexed as **%s**", kind)
+	if kind == store.KindEphemeral {
+		kindNote += fmt.Sprintf(
+			" (24h TTL, excluded from default search — use `source: %q` or `include_kinds: [\"durable\",\"ephemeral\"]` for follow-up queries)",
+			indexed.Label,
+		)
+	}
+
 	text := fmt.Sprintf(
-		"Fetched and indexed **%d sections** (%sKB) from: %s\nFull content indexed in sandbox — use search(queries: [...], source: %q) for specific lookups.\n\n---\n\n%s",
-		indexed.TotalChunks, totalKB, indexed.Label, indexed.Label, preview,
+		"Fetched and indexed **%d sections** (%sKB) from: %s\n%s\nUse search(queries: [...], source: %q) for specific lookups.\n\n---\n\n%s",
+		indexed.TotalChunks, totalKB, indexed.Label, kindNote, indexed.Label, preview,
 	)
 
 	return s.trackToolResponse("capy_fetch_and_index", textResult(text)), nil

--- a/internal/server/tool_fetch_test.go
+++ b/internal/server/tool_fetch_test.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/serpro69/capy/internal/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPlainTextServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func assertSourceKind(t *testing.T, srv *Server, label string, want store.SourceKind) {
+	t.Helper()
+	meta, err := srv.getStore().GetSourceMeta(label)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, want, meta.Kind)
+}
+
+func TestFetchAndIndex_KindDefaultsToEphemeral(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "ephemeral by default")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-default",
+	})
+	assert.False(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "ephemeral")
+	assertSourceKind(t, srv, "kind-default", store.KindEphemeral)
+}
+
+func TestFetchAndIndex_KindDurable(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "durable content")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-durable",
+		"kind":   "durable",
+	})
+	assert.False(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "durable")
+	assertSourceKind(t, srv, "kind-durable", store.KindDurable)
+}
+
+func TestFetchAndIndex_KindEphemeralExplicit(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "explicit ephemeral")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-ephemeral",
+		"kind":   "ephemeral",
+	})
+	assert.False(t, r.IsError)
+	assertSourceKind(t, srv, "kind-ephemeral", store.KindEphemeral)
+}
+
+func TestFetchAndIndex_KindInvalidRejected(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "should not be reached")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":  ts.URL,
+		"kind": "invalid",
+	})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "Invalid kind")
+	assert.Contains(t, text, "invalid")
+}
+
+func TestFetchAndIndex_KindSessionRejected(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "should not be reached")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":  ts.URL,
+		"kind": "session",
+	})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "Invalid kind")
+	assert.Contains(t, text, "session")
+}
+
+func TestFetchAndIndex_CacheBypassedOnKindMismatch(t *testing.T) {
+	disableSSRFValidation(t)
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, "content version %d", calls)
+	}))
+	t.Cleanup(ts.Close)
+
+	srv := newTestServer(t, nil)
+
+	// First fetch: default (ephemeral)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-mismatch",
+	})
+	assert.False(t, r.IsError)
+	assert.Equal(t, 1, calls)
+	assertSourceKind(t, srv, "kind-mismatch", store.KindEphemeral)
+
+	// Second fetch with kind=durable within cache TTL — must bypass cache and re-fetch
+	r = callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-mismatch",
+		"kind":   "durable",
+	})
+	assert.False(t, r.IsError)
+	assert.Equal(t, 2, calls, "cache must be bypassed when requested kind differs from cached kind")
+	assert.NotContains(t, resultText(r), "Cache hit")
+	assertSourceKind(t, srv, "kind-mismatch", store.KindDurable)
+}
+
+func TestFetchAndIndex_CacheBypassedOnKindMismatch_DurableToEphemeral(t *testing.T) {
+	disableSSRFValidation(t)
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, "content version %d", calls)
+	}))
+	t.Cleanup(ts.Close)
+
+	srv := newTestServer(t, nil)
+
+	// First fetch: durable
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-mismatch-rev",
+		"kind":   "durable",
+	})
+	require.False(t, r.IsError)
+	assert.Equal(t, 1, calls)
+	assertSourceKind(t, srv, "kind-mismatch-rev", store.KindDurable)
+
+	// Second fetch: default ephemeral — must bypass cache
+	r = callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-mismatch-rev",
+	})
+	assert.False(t, r.IsError)
+	assert.Equal(t, 2, calls, "cache must be bypassed when requested kind differs from cached kind")
+	assertSourceKind(t, srv, "kind-mismatch-rev", store.KindEphemeral)
+}
+
+func TestFetchAndIndex_CacheHitWhenKindMatches(t *testing.T) {
+	disableSSRFValidation(t)
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, "content version %d", calls)
+	}))
+	t.Cleanup(ts.Close)
+
+	srv := newTestServer(t, nil)
+
+	// First fetch: durable
+	callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-cache-match",
+		"kind":   "durable",
+	})
+	assert.Equal(t, 1, calls)
+
+	// Second fetch: also durable — should hit cache
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "kind-cache-match",
+		"kind":   "durable",
+	})
+	assert.False(t, r.IsError)
+	assert.Equal(t, 1, calls, "same kind should use cache")
+	assert.Contains(t, resultText(r), "Cache hit")
+}
+
+func TestFetchAndIndex_ResponseTextIncludesEphemeralHint(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "ephemeral hint test content")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "hint-test",
+	})
+	assert.False(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "ephemeral")
+	assert.Contains(t, text, "source:")
+	assert.Contains(t, text, "include_kinds")
+}
+
+func TestFetchAndIndex_ResponseTextDurableNoEphemeralHint(t *testing.T) {
+	disableSSRFValidation(t)
+	ts := newPlainTextServer(t, "durable hint test content")
+
+	srv := newTestServer(t, nil)
+	r := callFetchAndIndex(t, srv, map[string]any{
+		"url":    ts.URL,
+		"source": "durable-hint",
+		"kind":   "durable",
+	})
+	assert.False(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "durable")
+	assert.NotContains(t, text, "excluded from default search")
+}

--- a/internal/server/tool_knowledge_test.go
+++ b/internal/server/tool_knowledge_test.go
@@ -230,46 +230,37 @@ func TestSearch_NoResults_ShowsSources(t *testing.T) {
 	assert.False(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "No results found")
-	assert.Contains(t, text, "Indexed sources:", "must show the source list when all queries return empty")
-	assert.Contains(t, text, "react-docs", "must name the indexed durable source in the fallback listing")
+	assert.Contains(t, text, "1 durable", "must show durable count in fallback summary")
+	assert.Contains(t, text, "source(s) indexed", "must show the count summary when all queries return empty")
+	assert.Contains(t, text, "capy_stats", "must point to capy_stats for details")
+	assert.NotContains(t, text, "react-docs", "must NOT leak individual source labels")
 }
 
-func TestSearch_NoResults_HidesEphemeralSources(t *testing.T) {
+func TestSearch_NoResults_HidesEphemeralFromCountSummary(t *testing.T) {
 	srv := newTestServer(t, nil)
 	seedMixedKindCorpus(t, srv) // seeds one durable (k8s-docs) and one ephemeral (execute:shell)
 
-	// extractIndexedSourcesSection returns the text after "Indexed sources:" so that
-	// assertions target only the fallback listing, not the ephemeral-recovery hint
-	// (which names "execute:shell" as an example).
-	extract := func(text string) string {
-		_, after, ok := strings.Cut(text, "Indexed sources:")
-		if !ok {
-			return ""
-		}
-		return after
-	}
-
-	// Default call: ephemeral is excluded from both search and the fallback listing.
+	// Default call: ephemeral is excluded — count summary should show durable only.
 	r := callSearch(t, srv, map[string]any{
 		"queries": []any{"xyznonexistentterm123"},
 	})
 	assert.False(t, r.IsError)
 	text := resultText(r)
-	listing := extract(text)
-	require.NotEmpty(t, listing, "fallback listing must be present")
-	assert.Contains(t, listing, "k8s-docs", "durable source must appear in fallback listing")
-	assert.NotContains(t, listing, "execute:shell", "ephemeral source must NOT appear in the listing by default")
+	assert.Contains(t, text, "1 durable", "count summary must include durable sources")
+	assert.NotContains(t, text, "1 ephemeral source(s) indexed", "ephemeral must NOT appear in count summary by default")
+	assert.NotContains(t, text, "session", "no session sources seeded — must not appear")
+	assert.NotContains(t, text, "k8s-docs", "individual source labels must not appear")
+	assert.NotContains(t, text, "execute:shell", "individual source labels must not appear")
 
-	// Opting into ephemeral lists both kinds.
+	// Opting into ephemeral includes it in the count summary.
 	r = callSearch(t, srv, map[string]any{
 		"queries":       []any{"xyznonexistentterm123"},
 		"include_kinds": []any{"durable", "ephemeral"},
 	})
 	assert.False(t, r.IsError)
-	listing = extract(resultText(r))
-	require.NotEmpty(t, listing)
-	assert.Contains(t, listing, "k8s-docs")
-	assert.Contains(t, listing, "execute:shell", "opting into ephemeral surfaces it in the fallback listing")
+	text = resultText(r)
+	assert.Contains(t, text, "1 durable", "durable count must appear")
+	assert.Contains(t, text, "1 ephemeral", "opting into ephemeral surfaces it in count summary")
 }
 
 // seedMixedKindCorpus seeds the store with one durable and one ephemeral source,
@@ -364,7 +355,7 @@ func TestSearch_ZeroResultsNamesRecoveryPaths(t *testing.T) {
 	assert.Contains(t, text, "No results found")
 	// Both recovery paths must be named.
 	assert.Contains(t, text, `include_kinds: ["durable","ephemeral"]`)
-	assert.Contains(t, text, `source: "execute:`)
+	assert.Contains(t, text, `source: "<label>"`)
 	assert.Contains(t, text, "ephemeral source(s) present but excluded")
 }
 
@@ -397,7 +388,7 @@ func TestSearch_SessionRecoveryJourney(t *testing.T) {
 	text := resultText(r)
 	assert.Contains(t, text, "No results found")
 	assert.Contains(t, text, `include_kinds: ["durable","ephemeral"]`)
-	assert.Contains(t, text, `source: "execute:`)
+	assert.Contains(t, text, `source: "<label>"`)
 
 	// Same query with include_kinds: ["ephemeral"] must surface the ephemeral hit.
 	r = callSearch(t, srv, map[string]any{
@@ -476,6 +467,91 @@ func TestSearch_OutputCap(t *testing.T) {
 	assert.False(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "output cap reached")
+}
+
+func indexAs(t *testing.T, srv *Server, content, label string, kind store.SourceKind) {
+	t.Helper()
+	st := srv.getStore()
+	_, err := st.IndexPlainText(content, label, kind)
+	require.NoError(t, err)
+}
+
+func TestSearch_NoResults_ShowsCountSummary(t *testing.T) {
+	srv := newTestServer(t, nil)
+
+	indexAs(t, srv, "Golang testing patterns and best practices for unit tests", "go-testing", store.KindDurable)
+	indexAs(t, srv, "Python data science libraries overview and tutorials", "python-ds", store.KindDurable)
+
+	r := callSearch(t, srv, map[string]any{
+		"queries": []string{"xyznonexistent12345"},
+	})
+
+	text := resultText(r)
+	assert.Contains(t, text, "2 durable")
+	assert.Contains(t, text, "source(s) indexed")
+	assert.Contains(t, text, "capy_stats")
+	assert.NotContains(t, text, "go-testing")
+	assert.NotContains(t, text, "python-ds")
+}
+
+func TestSearch_NoResults_CountSummaryRespectsKindScope(t *testing.T) {
+	srv := newTestServer(t, nil)
+
+	indexAs(t, srv, "Durable reference documentation content here", "ref-docs", store.KindDurable)
+	indexAs(t, srv, "Ephemeral command output from shell execution", "execute:shell", store.KindEphemeral)
+	indexAs(t, srv, "Session transcript from past conversation", "session:abc", store.KindSession)
+
+	r := callSearch(t, srv, map[string]any{
+		"queries": []string{"xyznonexistent12345"},
+	})
+	text := resultText(r)
+	assert.Contains(t, text, "1 durable")
+	assert.Contains(t, text, "1 session")
+	assert.NotContains(t, text, "1 ephemeral source(s) indexed")
+
+	r = callSearch(t, srv, map[string]any{
+		"queries":       []string{"xyznonexistent12345"},
+		"include_kinds": []string{"durable", "ephemeral"},
+	})
+	text = resultText(r)
+	assert.Contains(t, text, "1 durable")
+	assert.Contains(t, text, "1 ephemeral")
+	assert.NotContains(t, text, "1 session source(s) indexed")
+}
+
+func TestSearch_NoResults_EphemeralHintMentionsFetchedContent(t *testing.T) {
+	srv := newTestServer(t, nil)
+
+	indexAs(t, srv, "Some ephemeral content from a fetched web page", "fetch:example.com", store.KindEphemeral)
+
+	r := callSearch(t, srv, map[string]any{
+		"queries": []string{"xyznonexistent12345"},
+	})
+
+	text := resultText(r)
+	assert.Contains(t, text, "ephemeral source(s) present but excluded")
+	assert.Contains(t, text, "fetched web pages")
+	assert.Contains(t, text, "capy_fetch_and_index")
+	assert.Contains(t, text, "source: \"<label>\"")
+}
+
+func TestSearch_NoResults_NoSourceLabelsLeaked(t *testing.T) {
+	srv := newTestServer(t, nil)
+
+	indexAs(t, srv, "Alpha documentation about widget configuration", "alpha-docs", store.KindDurable)
+	indexAs(t, srv, "Beta release notes and migration guide", "beta-notes", store.KindDurable)
+	indexAs(t, srv, "Command output from shell grep command", "execute:shell", store.KindEphemeral)
+
+	r := callSearch(t, srv, map[string]any{
+		"queries":       []string{"xyznonexistent12345"},
+		"include_kinds": []string{"durable", "ephemeral"},
+	})
+
+	text := resultText(r)
+	assert.NotContains(t, text, "alpha-docs")
+	assert.NotContains(t, text, "beta-notes")
+	assert.NotContains(t, text, "execute:shell")
+	assert.NotContains(t, text, "sections)")
 }
 
 // ─── Fetch and Index tests ─────────────────────────────────────────────────────

--- a/internal/server/tool_knowledge_test.go
+++ b/internal/server/tool_knowledge_test.go
@@ -532,6 +532,7 @@ func TestSearch_NoResults_EphemeralHintMentionsFetchedContent(t *testing.T) {
 	assert.Contains(t, text, "ephemeral source(s) present but excluded")
 	assert.Contains(t, text, "fetched web pages")
 	assert.Contains(t, text, "capy_fetch_and_index")
+	assert.Contains(t, text, "capy_execute_file")
 	assert.Contains(t, text, "source: \"<label>\"")
 }
 

--- a/internal/server/tool_search.go
+++ b/internal/server/tool_search.go
@@ -124,9 +124,9 @@ func (s *Server) handleSearch(_ context.Context, req mcp.CallToolRequest) (*mcp.
 				}
 				if ephemeralCount > 0 {
 					noResults += fmt.Sprintf(
-						"\n\n%d ephemeral source(s) present but excluded by default. To include command output from capy_execute / capy_execute_file / capy_batch_execute, retry with:\n"+
+						"\n\n%d ephemeral source(s) present but excluded by default. Ephemeral sources include command output (capy_execute / capy_batch_execute) and fetched web pages (capy_fetch_and_index). To include them, retry with:\n"+
 							"  • include_kinds: [\"durable\",\"ephemeral\"]  (search across both kinds), or\n"+
-							"  • source: \"execute:<lang>\" / \"file:<path>\" / \"batch:…\"  (explicit-source override; e.g., source: \"execute:shell\")",
+							"  • source: \"<label>\"  (explicit-source filter bypasses kind filtering)",
 						ephemeralCount,
 					)
 				}
@@ -176,25 +176,22 @@ func (s *Server) handleSearch(_ context.Context, req mcp.CallToolRequest) (*mcp.
 		)
 	}
 
-	// When no query produced any results, append the list of indexed sources
-	// to help the caller pick a better query. Preserves per-query messages
-	// (including the ephemeral-recovery hint) by appending rather than overwriting.
-	// Ephemeral labels are filtered out unless the caller opted into ephemeral,
-	// to keep the listing consistent with the default-exclude-ephemeral contract.
+	// Count sources for each kind within the caller's search scope.
+	// Only *included* kinds are counted here; *excluded* kinds are handled by
+	// the per-query ephemeral/session hints above (the two paths are disjoint).
 	if !hasResults {
-		sources, _ := st.ListSources()
-		var parts []string
-		for _, src := range sources {
-			if ephemeralExcluded && src.Kind == store.KindEphemeral {
+		countParts := make([]string, 0, 3)
+		for _, kind := range []store.SourceKind{store.KindDurable, store.KindEphemeral, store.KindSession} {
+			if !store.KindScopeIncludes(searchOpts, kind) {
 				continue
 			}
-			if sessionExcluded && src.Kind == store.KindSession {
-				continue
+			n, err := st.CountSourcesByKind(kind)
+			if err == nil && n > 0 {
+				countParts = append(countParts, fmt.Sprintf("%d %s", n, kind))
 			}
-			parts = append(parts, fmt.Sprintf("%q (%d sections)", src.Label, src.ChunkCount))
 		}
-		if len(parts) > 0 {
-			output += "\n\nIndexed sources: " + strings.Join(parts, ", ")
+		if len(countParts) > 0 {
+			output += fmt.Sprintf("\n\n%s source(s) indexed. Refine your query terms, or use capy_stats for source details.", strings.Join(countParts, ", "))
 		}
 	}
 

--- a/internal/server/tool_search.go
+++ b/internal/server/tool_search.go
@@ -124,7 +124,7 @@ func (s *Server) handleSearch(_ context.Context, req mcp.CallToolRequest) (*mcp.
 				}
 				if ephemeralCount > 0 {
 					noResults += fmt.Sprintf(
-						"\n\n%d ephemeral source(s) present but excluded by default. Ephemeral sources include command output (capy_execute / capy_batch_execute) and fetched web pages (capy_fetch_and_index). To include them, retry with:\n"+
+						"\n\n%d ephemeral source(s) present but excluded by default. Ephemeral sources include command output (capy_execute / capy_execute_file / capy_batch_execute) and fetched web pages (capy_fetch_and_index). To include them, retry with:\n"+
 							"  • include_kinds: [\"durable\",\"ephemeral\"]  (search across both kinds), or\n"+
 							"  • source: \"<label>\"  (explicit-source filter bypasses kind filtering)",
 						ephemeralCount,

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -118,7 +118,7 @@ func toolExecute(langList string) mcp.Tool {
 	return mcp.NewTool("capy_execute",
 		mcp.WithToolAnnotation(annotationExecute),
 		mcp.WithDescription(fmt.Sprintf(
-			"MANDATORY: Use for any command where output exceeds 20 lines. Execute code in a sandboxed subprocess. Only stdout enters context — raw data stays in the subprocess. Available: [%s]. PREFER THIS OVER BASH for: API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff), data processing, and ANY CLI command that may produce large output. Bash should only be used for file mutations, git writes, and navigation.",
+			"Execute code in a sandboxed subprocess for large-output extraction. Only stdout enters context — raw data stays in the subprocess. Available: [%s]. Best for: API calls, broad searches (rg, grep), log analysis, data processing, and commands producing hundreds+ lines where you only need extracted facts. NOT for: git commands (use Bash), small-output commands (<50 lines, use Bash), content you need to comprehend fully (use Read/Bash).",
 			langList,
 		)),
 		mcp.WithString("language",
@@ -146,7 +146,7 @@ func toolExecuteFile(langList string) mcp.Tool {
 	return mcp.NewTool("capy_execute_file",
 		mcp.WithToolAnnotation(annotationExecute),
 		mcp.WithDescription(fmt.Sprintf(
-			"Read a file and process it without loading contents into context. The file is read into a FILE_CONTENT variable inside the sandbox. Only your printed summary enters context. Available: [%s]. PREFER THIS OVER Read/cat for: log files, data files (CSV, JSON, XML), large source files for analysis.",
+			"Read a file and process it without loading contents into context. The file is read into a FILE_CONTENT variable inside the sandbox. Only your printed summary enters context. Available: [%s]. Best for large files (10k+ lines) where you only need derived answers (counts, patterns, structural summary). Read is correct when you need to understand or edit the file.",
 			langList,
 		)),
 		mcp.WithString("path",
@@ -190,7 +190,7 @@ func toolIndex() mcp.Tool {
 func toolSearch() mcp.Tool {
 	return mcp.NewTool("capy_search",
 		mcp.WithToolAnnotation(annotationReadOnly),
-		mcp.WithDescription("Search indexed content. Pass ALL search questions as queries array in ONE call. TIPS: 2-4 specific terms per query. Use 'source' to scope results. By default returns only durable sources (fetched/indexed reference content); ephemeral command output is excluded — pass include_kinds: [\"durable\",\"ephemeral\"] or an explicit source: filter to recover it."),
+		mcp.WithDescription("Search indexed content. Pass ALL search questions as queries array in ONE call. TIPS: 2-4 specific terms per query. Use 'source' to scope results. By default returns durable and session sources; ephemeral content (command output, fetched web pages) is excluded — pass include_kinds: [\"durable\",\"ephemeral\"] or an explicit source: filter to recover it."),
 		mcp.WithArray("queries",
 			mcp.Description("Array of search queries. Batch ALL questions in one call."),
 			mcp.Items(map[string]any{"type": "string"}),
@@ -202,7 +202,7 @@ func toolSearch() mcp.Tool {
 			mcp.Description("Filter to a specific indexed source (partial match). When set, kind filtering is bypassed — caller's named source wins."),
 		),
 		mcp.WithArray("include_kinds",
-			mcp.Description("Source kinds to include. Accepted values: \"durable\" (fetched/indexed reference content, retained by retention score), \"ephemeral\" (auto-indexed command output from capy_execute / capy_execute_file / capy_batch_execute, swept by TTL), and \"session\" (past conversation transcripts indexed by `capy sweep`, swept by TTL). Default: [\"durable\"] only. Use [\"durable\",\"ephemeral\"] to recover prior command output, or [\"durable\",\"session\"] to search past conversations."),
+			mcp.Description("Source kinds to include. Accepted values: \"durable\" (explicitly indexed reference content, retained by retention score), \"ephemeral\" (auto-indexed command output and fetched web pages, swept by TTL), and \"session\" (past conversation transcripts indexed by `capy sweep`, swept by TTL). Default: [\"durable\", \"session\"]. Use [\"durable\",\"ephemeral\"] to recover prior command output or fetched pages, or [\"durable\",\"ephemeral\",\"session\"] to search everything."),
 			mcp.Items(map[string]any{"type": "string", "enum": []string{"durable", "ephemeral", "session"}}),
 		),
 	)
@@ -211,7 +211,7 @@ func toolSearch() mcp.Tool {
 func toolFetchAndIndex() mcp.Tool {
 	return mcp.NewTool("capy_fetch_and_index",
 		mcp.WithToolAnnotation(annotationFetch),
-		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes into searchable knowledge base, and returns a ~3KB preview. Full content stays in sandbox — use capy_search for deeper lookups. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
+		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
 		mcp.WithString("url",
 			mcp.Required(),
 			mcp.Description("The URL to fetch and index"),
@@ -232,7 +232,7 @@ func toolFetchAndIndex() mcp.Tool {
 func toolBatchExecute() mcp.Tool {
 	return mcp.NewTool("capy_batch_execute",
 		mcp.WithToolAnnotation(annotationExecute),
-		mcp.WithDescription("Execute multiple commands in ONE call, auto-index all output, and search with multiple queries. Returns search results directly — no follow-up calls needed. THIS IS THE PRIMARY TOOL. Use this instead of multiple execute() calls."),
+		mcp.WithDescription("Execute multiple commands in ONE call, auto-index all output, and search with multiple queries. Returns search results directly — no follow-up calls needed. Best for broad exploration passes where you need to run multiple commands and extract specific answers from combined output. NOT for: git diffs, small commands, or content you need to read fully."),
 		mcp.WithArray("commands",
 			mcp.Required(),
 			mcp.Description("Commands to execute as a batch. Each command object has: label (section header), command (shell command to execute)."),

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -222,6 +222,10 @@ func toolFetchAndIndex() mcp.Tool {
 		mcp.WithBoolean("force",
 			mcp.Description("Skip cache and re-fetch even if content was recently indexed"),
 		),
+		mcp.WithString("kind",
+			mcp.Description("Source kind for indexed content: 'ephemeral' (default, 24h TTL, excluded from default search) or 'durable' (retained by retention score, included in default search). Use 'durable' for reference docs you want to persist across sessions."),
+			mcp.Enum("durable", "ephemeral"),
+		),
 	)
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -557,7 +557,7 @@ func (s *ContentStore) CountSourcesByKind(kind SourceKind) (int, error) {
 
 // effectiveKindFilter resolves the source-kind filter to apply for a search:
 //   - explicit Source set: nil (caller named a source; trust the intent)
-//   - empty IncludeKinds: {KindDurable} (default-exclude ephemeral)
+//   - empty IncludeKinds: {KindDurable, KindSession} (default-exclude ephemeral)
 //   - non-empty IncludeKinds: opts.IncludeKinds verbatim
 //
 // Returning nil means "no kind clause." Returning a slice means "filter to these kinds."

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -30,7 +30,7 @@ type SearchOptions struct {
 	ContentType     string       // "code", "prose", or "" (no filter) — internal only, not in MCP schema
 	SourceMatchMode string       // "like" (default) or "exact"
 	MaxPerSource    int          // per-source result cap for diversification; 0 = default (2)
-	IncludeKinds    []SourceKind // empty = default (durable only); ignored when Source != ""
+	IncludeKinds    []SourceKind // empty = default (durable + session); ignored when Source != ""
 }
 
 // SearchResult is a single result from a search query.


### PR DESCRIPTION
Addresses over-preservation of task artifacts and over-routing through
capy where BM25 fragmentation hurts quality. Decisions: fetch defaults
to ephemeral, AGENTS.md full rewrite to task-aware routing, search
fallback capped to summary-only.

## Test Plan
n/a