### PR TITLE
(fix) Clarify web-content routing: comprehension vs extraction (#47)

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -16,12 +16,13 @@ Choose the tool based on what you need from the output:
 - **Files to comprehend or edit:** Read tool. Required before Edit.
 - **Sequential/ordered content:** test output, build logs where order matters — Bash or Read.
 - **Instruction files, checklists, configs:** Read and internalize whole. BM25 returns ranked fragments, destroying structural relationships.
+- **Small authoritative web pages:** GitHub issues, PR descriptions, short specs, doc pages — use runtime-native tools when available (e.g., `gh issue view` for GitHub, `WebSearch` for general queries). These are comprehension content; BM25 fragments destroy context just as they do for diffs.
 
 ## When to use capy tools
 
 - **`capy_batch_execute`:** Broad exploration — multiple commands + queries in one call. Example: initial repo scan with `rg --files` + symbol searches.
 - **`capy_execute` / `capy_execute_file`:** Single command or file producing hundreds+ lines where you only need extracted facts. API calls, log analysis, data processing.
-- **`capy_fetch_and_index`:** Fetch web content. Default ephemeral (24h TTL, excluded from default search). Pass `kind: "durable"` for reference docs. Use `source: "<label>"` for follow-up search.
+- **`capy_fetch_and_index`:** Fetch and index large web content for extraction. Default ephemeral (24h TTL, excluded from default search). Best for large web artifacts (transcripts, logs, long docs) and content needing follow-up `source:` queries. Pass `kind: "durable"` for reference docs to persist across sessions. NOT for small authoritative pages you need to comprehend — use runtime web tools for those.
 - **`capy_index`:** Persist curated knowledge durably. Content you explicitly want searchable across sessions.
 - **`capy_search`:** Query indexed content. Batch all questions as array. Default excludes ephemeral — use `include_kinds` or `source:` to include.
 
@@ -42,6 +43,8 @@ Instead use:
 WebFetch calls are denied entirely. The URL is extracted and you are told to use `capy_fetch_and_index` instead.
 Instead use:
 - `capy_fetch_and_index(url, source)` then `capy_search(queries)` to query the indexed content
+
+**Note:** These blocks prevent raw HTTP output from flooding context. For web *comprehension* of small authoritative pages, use runtime-native tools when available (`gh` CLI for GitHub content, `WebSearch` for general queries). `capy_fetch_and_index` remains the correct path for large web content and extraction.
 
 ## Source kinds
 

--- a/internal/hook/routing.go
+++ b/internal/hook/routing.go
@@ -18,13 +18,14 @@ func RoutingBlock() string {
     - Files to comprehend or edit (Read)
     - Sequential/ordered content (test output, build logs)
     - Instruction files, checklists, configs (Read whole)
+    - Small authoritative web pages (issues, PRs, specs) — runtime web tools (gh, WebSearch) when available
   </direct_tools>
 
   <capy_tools>
     Use capy for:
     - capy_batch_execute: broad exploration, multiple commands + queries in ONE call
     - capy_execute / capy_execute_file: large-output extraction (hundreds+ lines)
-    - capy_fetch_and_index: web content (default ephemeral; kind: "durable" for reference docs)
+    - capy_fetch_and_index: large web content for extraction (default ephemeral; kind: "durable" for reference docs). NOT for small pages needing comprehension — use runtime web tools
     - capy_search: query indexed content (batch questions as array)
   </capy_tools>
 
@@ -32,6 +33,7 @@ func RoutingBlock() string {
     - curl/wget in Bash → use capy_fetch_and_index or capy_execute
     - Inline HTTP in Bash → use capy_execute
     - WebFetch → use capy_fetch_and_index
+    Note: For web comprehension, use runtime-native tools (gh, WebSearch) when available
   </blocked>
 
   <output_constraints>

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -34,12 +34,13 @@ Choose the tool based on what you need from the output:
 - **Files to comprehend or edit:** Read tool. Required before Edit.
 - **Sequential/ordered content:** test output, build logs where order matters — Bash or Read.
 - **Instruction files, checklists, configs:** Read and internalize whole. BM25 returns ranked fragments, destroying structural relationships.
+- **Small authoritative web pages:** GitHub issues, PR descriptions, short specs, doc pages — use runtime-native tools when available (e.g., ` + "`gh issue view`" + ` for GitHub, ` + "`WebSearch`" + ` for general queries). These are comprehension content; BM25 fragments destroy context just as they do for diffs.
 
 ## When to use capy tools
 
 - **` + "`capy_batch_execute`" + `:** Broad exploration — multiple commands + queries in one call. Example: initial repo scan with ` + "`rg --files`" + ` + symbol searches.
 - **` + "`capy_execute`" + ` / ` + "`capy_execute_file`" + `:** Single command or file producing hundreds+ lines where you only need extracted facts. API calls, log analysis, data processing.
-- **` + "`capy_fetch_and_index`" + `:** Fetch web content. Default ephemeral (24h TTL, excluded from default search). Pass ` + "`kind: \"durable\"`" + ` for reference docs. Use ` + "`source: \"<label>\"`" + ` for follow-up search.
+- **` + "`capy_fetch_and_index`" + `:** Fetch and index large web content for extraction. Default ephemeral (24h TTL, excluded from default search). Best for large web artifacts (transcripts, logs, long docs) and content needing follow-up ` + "`source:`" + ` queries. Pass ` + "`kind: \"durable\"`" + ` for reference docs to persist across sessions. NOT for small authoritative pages you need to comprehend — use runtime web tools for those.
 - **` + "`capy_index`" + `:** Persist curated knowledge durably. Content you explicitly want searchable across sessions.
 - **` + "`capy_search`" + `:** Query indexed content. Batch all questions as array. Default excludes ephemeral — use ` + "`include_kinds`" + ` or ` + "`source:`" + ` to include.
 
@@ -60,6 +61,8 @@ Instead use:
 WebFetch calls are denied entirely. The URL is extracted and you are told to use ` + "`capy_fetch_and_index`" + ` instead.
 Instead use:
 - ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + ` to query the indexed content
+
+**Note:** These blocks prevent raw HTTP output from flooding context. For web *comprehension* of small authoritative pages, use runtime-native tools when available (` + "`gh`" + ` CLI for GitHub content, ` + "`WebSearch`" + ` for general queries). ` + "`capy_fetch_and_index`" + ` remains the correct path for large web content and extraction.
 
 ## Source kinds
 

--- a/internal/platform/routing_test.go
+++ b/internal/platform/routing_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/serpro69/capy/internal/hook"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,6 +43,26 @@ func TestGenerateRoutingInstructions(t *testing.T) {
 
 	// Must reference sandbox execution
 	assert.Contains(t, instructions, "sandbox")
+
+	// Must distinguish web comprehension from web extraction (issue #47)
+	assert.Contains(t, instructions, "authoritative web pages",
+		"routing instructions should guide web comprehension to direct tools")
+	assert.Contains(t, instructions, "gh issue view",
+		"routing instructions should mention gh CLI as a runtime web tool")
+	assert.Contains(t, instructions, "WebSearch",
+		"routing instructions should mention WebSearch as a runtime web tool")
+}
+
+func TestRoutingBlockWebComprehension(t *testing.T) {
+	block := hook.RoutingBlock()
+
+	// Must distinguish web comprehension from extraction (issue #47)
+	assert.Contains(t, block, "authoritative web pages",
+		"routing block should mention authoritative web pages for comprehension")
+	assert.Contains(t, block, "runtime web tools",
+		"routing block should reference runtime web tools as alternative")
+	assert.Contains(t, block, "web comprehension",
+		"routing block blocked section should mention web comprehension alternative")
 }
 
 func TestCapyToolNamesComplete(t *testing.T) {

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -211,7 +211,7 @@ func toolSearch() mcp.Tool {
 func toolFetchAndIndex() mcp.Tool {
 	return mcp.NewTool("capy_fetch_and_index",
 		mcp.WithToolAnnotation(annotationFetch),
-		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
+		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Best for large web artifacts where you need extracted facts or follow-up searchable context. For small authoritative pages (issues, PRs, specs) you need to comprehend fully, prefer runtime-native tools (gh CLI, WebSearch) when available. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
 		mcp.WithString("url",
 			mcp.Required(),
 			mcp.Description("The URL to fetch and index"),


### PR DESCRIPTION
Extend the comprehension-vs-extraction principle to web content across
all three routing surfaces, tool description, and tests.

## Test Plan
```
make test
```