### PR TITLE
(fix) Add hook-level friction for git platform URLs in capy_fetch_and_index (#49)

### DIFF
--- a/.capy/AGENTS.md
+++ b/.capy/AGENTS.md
@@ -40,11 +40,10 @@ Instead use:
 - `capy_execute(language, code)` to run HTTP calls in sandbox — only stdout enters context
 
 ### WebFetch — BLOCKED
-WebFetch calls are denied entirely. The URL is extracted and you are told to use `capy_fetch_and_index` instead.
-Instead use:
-- `capy_fetch_and_index(url, source)` then `capy_search(queries)` to query the indexed content
-
-**Note:** These blocks prevent raw HTTP output from flooding context. For web *comprehension* of small authoritative pages, use runtime-native tools when available (`gh` CLI for GitHub content, `WebSearch` for general queries). `capy_fetch_and_index` remains the correct path for large web content and extraction.
+WebFetch calls are denied entirely. Instead use:
+- For git platform issues/PRs/MRs: platform CLI (e.g., `gh issue view N`) or `WebSearch` for full comprehension
+- For other small pages needing comprehension: `WebSearch` or other runtime web tools
+- For large web content or extraction: `capy_fetch_and_index(url, source)` then `capy_search(queries)`
 
 ## Source kinds
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ internal/
   adapter/          Platform adapter interface + Claude Code implementation
   config/           TOML config loading, project root detection, path resolution
   executor/         Polyglot code executor (11 languages, process isolation)
+  giturl/           Git platform URL detection (shared by hook and server)
   hook/             Hook event routing (PreToolUse, PostToolUse, etc.)
   platform/         Setup command, doctor diagnostics, routing instructions
   security/         Settings parsing, glob matching, command splitting, shell-escape detection

--- a/docs/adr/024-server-side-git-url-enforcement.md
+++ b/docs/adr/024-server-side-git-url-enforcement.md
@@ -1,0 +1,74 @@
+# ADR-024: Server-side enforcement for git platform URLs in capy_fetch_and_index
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Amends:** ADR-023 (routing rewrite — extends enforcement from guidance-only to mechanical block).
+
+## Context
+
+Issue [#44](https://github.com/serpro69/capy/issues/44) (v0.9.0) established the comprehension-vs-extraction routing principle: git diffs, small commands, and sequential content use direct tools (Bash/Read); large-output extraction uses capy tools.
+
+Issue [#47](https://github.com/serpro69/capy/issues/47) (v0.9.1) extended the principle to web content via guidance-only changes: routing docs, tool descriptions, and blocked-WebFetch redirects were updated to say "for GitHub issues/PRs, use `gh issue view` instead of `capy_fetch_and_index`."
+
+Issue [#49](https://github.com/serpro69/capy/issues/49) demonstrated this was insufficient. In a Codex review session, the model had the rule in context but still routed a GitHub issue through `capy_fetch_and_index`. Post-mortem analysis identified two compounding failures:
+
+1. **Competing mechanical signals outweigh soft guidance.** The redirect chain — URL provided → model reaches for URL tool → WebFetch blocked → "use capy_fetch_and_index" — is concrete and highly salient. "Prefer runtime-native tools when available" is soft language that loses at decision time.
+
+2. **Client-side hooks don't fire in all runtimes.** PreToolUse hooks are registered in Claude Code's settings and execute in its client-side hook system. Codex has its own MCP client that calls capy's MCP server directly, bypassing the hooks entirely. The `FormatAllow` guidance added in v0.9.1 never reached the model.
+
+## Decision
+
+### D1: Server-side block in `handleFetchAndIndex`
+
+When `capy_fetch_and_index` receives a URL matching a git platform issue/PR/MR pattern, the MCP server returns a redirect message instead of fetching. No HTTP request is made. The response names the specific alternative command (e.g., `gh issue view 44 --repo serpro69/capy` for GitHub).
+
+This is the only enforcement layer that works for ALL MCP clients — Claude Code, Codex, Cursor, or any future client — because it operates inside the MCP server, not in a client-specific hook system.
+
+### D2: Client-side hook upgraded from FormatAllow to FormatBlock
+
+The PreToolUse hook for `capy_fetch_and_index` with git platform URLs now uses `FormatBlock` (hard deny) instead of `FormatAllow` (advisory context). For clients that do run hooks (Claude Code), this provides belt-and-suspenders: the hook blocks the call before it reaches the MCP server.
+
+Gist URLs remain `FormatAllow` — they can legitimately be large extraction targets where BM25 indexing is appropriate.
+
+### D3: Shared `internal/giturl` package
+
+URL detection logic is needed by both `internal/hook` (client-side enforcement) and `internal/server` (MCP server-side enforcement). These packages have no existing dependency on each other and creating one would be architecturally wrong — `hook` is client middleware; `server` is the MCP server.
+
+The shared `internal/giturl` package exports `ParsePlatformURL` and `IsGistURL`. Both consumers import the shared package independently.
+
+### D4: Platform-generic detection
+
+URL matching is not hardcoded to GitHub. `ParsePlatformURL` recognizes:
+
+- **GitHub:** `owner/repo/issues/N`, `owner/repo/pull/N`
+- **GitLab:** `.../-/issues/N`, `.../-/merge_requests/N`
+- **Bitbucket:** `.../pull-requests/N`
+- **Gitea:** `.../issues/N`, `.../pulls/N`
+- **Generic:** any URL containing `/issues/N`, `/pull/N`, `/pulls/N`, `/pull-requests/N`, or `/merge_requests/N`
+
+GitHub URLs get specific `gh` CLI suggestions (since `gh` is widely available). Other platforms get generic "use your platform's CLI or WebSearch" guidance.
+
+### D5: No "use capy_index later" escape hatch
+
+The block message does not suggest fetching via `gh` and then indexing with `capy_index`. Comprehension via the platform CLI is the end goal, not a step toward re-indexing. Suggesting `capy_index` would make ephemeral comprehension content durable unnecessarily, contradicting the ephemeral-by-default principle from ADR-023.
+
+## Consequences
+
+- `capy_fetch_and_index` will refuse to fetch any URL that matches a git platform issue/PR/MR pattern. There is no override flag. If a legitimate use case for indexing an issue emerges (e.g., batch-scanning 50 issues), the user can fetch content via CLI and pipe it to `capy_index`.
+- Gists are not blocked — they can be arbitrarily large. The hook provides soft guidance; the server does not intercept gist URLs.
+- The `internal/giturl` package is a new dependency for both `hook` and `server`. It is intentionally minimal (~90 lines, no external dependencies) to keep the coupling surface small.
+- Adding new git platform patterns requires updating only `giturl.ParsePlatformURL`.
+
+## Alternatives considered
+
+### Guidance-only (rejected)
+
+Issues #47 and #49 demonstrated this is insufficient. Models have the rule in context but competing mechanical signals win at decision time. Two separate attempts at progressively stronger wording failed to change behavior.
+
+### FormatAllow with per-call guidance (rejected)
+
+Tried in the first iteration of #49. `FormatAllow` lets the tool proceed and injects guidance alongside the result. By the time the model sees the hint, it already has the BM25-fragmented results and has no reason to redo the work with `gh`. Additionally, `FormatAllow` only works in clients that run PreToolUse hooks.
+
+### Hard block with override flag (rejected)
+
+Adding a `force_git_platform: true` parameter to `capy_fetch_and_index` would give the model an easy escape hatch. The entire point of server-side enforcement is to make the wrong path mechanically impossible. The workaround for legitimate edge cases (fetch via CLI, then `capy_index`) is intentionally higher-friction.

--- a/internal/giturl/giturl.go
+++ b/internal/giturl/giturl.go
@@ -1,0 +1,97 @@
+package giturl
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Info holds parsed information about a git platform issue/PR URL.
+type Info struct {
+	Host   string // e.g. "github.com", "gitlab.com", "gitea.example.com"
+	Owner  string // populated for GitHub; may be empty for other platforms
+	Repo   string // populated for GitHub; may be empty for other platforms
+	Number string // issue/PR/MR number
+	Kind   string // "issue", "pr", or "mr"
+}
+
+// ParsePlatformURL detects if a URL points to a git platform issue, PR, or
+// merge request. Recognizes GitHub, GitLab, Bitbucket, Gitea, and generic
+// platforms using common path conventions (/issues/N, /pull/N, /merge_requests/N).
+func ParsePlatformURL(rawURL string) (Info, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return Info{}, false
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	info := Info{Host: u.Host}
+
+	// GitHub: owner/repo/issues/N or owner/repo/pull/N
+	if u.Host == "github.com" && len(parts) >= 4 {
+		info.Owner = parts[0]
+		info.Repo = parts[1]
+		switch parts[2] {
+		case "issues":
+			info.Number = parts[3]
+			info.Kind = "issue"
+			return info, true
+		case "pull":
+			info.Number = parts[3]
+			info.Kind = "pr"
+			return info, true
+		}
+	}
+
+	// Generic: scan for issue/PR markers at any path position.
+	// Covers GitLab (/-/issues/N, /-/merge_requests/N), Bitbucket
+	// (/issues/N, /pull-requests/N), Gitea (/issues/N, /pulls/N), and others.
+	for i := 0; i < len(parts)-1; i++ {
+		switch parts[i] {
+		case "issues":
+			info.Number = parts[i+1]
+			info.Kind = "issue"
+			return info, true
+		case "pull", "pulls", "pull-requests":
+			info.Number = parts[i+1]
+			info.Kind = "pr"
+			return info, true
+		case "merge_requests":
+			info.Number = parts[i+1]
+			info.Kind = "mr"
+			return info, true
+		}
+	}
+
+	return Info{}, false
+}
+
+// IsGistURL returns true for gist.github.com and gist.githubusercontent.com URLs.
+func IsGistURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return u.Host == "gist.github.com" || u.Host == "gist.githubusercontent.com"
+}
+
+// KindDisplay returns a human-readable name for the Kind field.
+func (i Info) KindDisplay() string {
+	if i.Kind == "mr" {
+		return "merge request"
+	}
+	return i.Kind
+}
+
+// GhCommand returns the gh CLI command for GitHub URLs, or empty string for other platforms.
+func (i Info) GhCommand() string {
+	if i.Host != "github.com" || i.Owner == "" {
+		return ""
+	}
+	switch i.Kind {
+	case "issue":
+		return "gh issue view " + i.Number + " --repo " + i.Owner + "/" + i.Repo
+	case "pr":
+		return "gh pr view " + i.Number + " --repo " + i.Owner + "/" + i.Repo
+	}
+	return ""
+}

--- a/internal/giturl/giturl_test.go
+++ b/internal/giturl/giturl_test.go
@@ -1,0 +1,80 @@
+package giturl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePlatformURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantHost   string
+		wantOwner  string
+		wantRepo   string
+		wantNumber string
+		wantKind   string
+		wantOK     bool
+	}{
+		{"GitHub issue", "https://github.com/serpro69/capy/issues/44", "github.com", "serpro69", "capy", "44", "issue", true},
+		{"GitHub PR", "https://github.com/serpro69/capy/pull/47", "github.com", "serpro69", "capy", "47", "pr", true},
+		{"GitHub issue with fragment", "https://github.com/serpro69/capy/issues/44#issuecomment-123", "github.com", "serpro69", "capy", "44", "issue", true},
+		{"GitHub PR with subpath", "https://github.com/serpro69/capy/pull/47/files", "github.com", "serpro69", "capy", "47", "pr", true},
+		{"GitLab issue", "https://gitlab.com/group/project/-/issues/123", "gitlab.com", "", "", "123", "issue", true},
+		{"GitLab MR", "https://gitlab.com/group/project/-/merge_requests/456", "gitlab.com", "", "", "456", "mr", true},
+		{"Bitbucket PR", "https://bitbucket.org/team/repo/pull-requests/78", "bitbucket.org", "", "", "78", "pr", true},
+		{"Gitea issue", "https://gitea.example.com/org/repo/issues/99", "gitea.example.com", "", "", "99", "issue", true},
+		{"Gitea pull", "https://gitea.example.com/org/repo/pulls/12", "gitea.example.com", "", "", "12", "pr", true},
+		{"repo root", "https://github.com/serpro69/capy", "", "", "", "", "", false},
+		{"issues listing", "https://github.com/serpro69/capy/issues", "", "", "", "", "", false},
+		{"gist", "https://gist.github.com/serpro69/abc123", "", "", "", "", "", false},
+		{"non-git URL", "https://docs.example.com/api/reference", "", "", "", "", "", false},
+		{"empty", "", "", "", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, ok := ParsePlatformURL(tt.url)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantHost, info.Host)
+				assert.Equal(t, tt.wantOwner, info.Owner)
+				assert.Equal(t, tt.wantRepo, info.Repo)
+				assert.Equal(t, tt.wantNumber, info.Number)
+				assert.Equal(t, tt.wantKind, info.Kind)
+			}
+		})
+	}
+}
+
+func TestIsGistURL(t *testing.T) {
+	assert.True(t, IsGistURL("https://gist.github.com/serpro69/abc123"))
+	assert.True(t, IsGistURL("https://gist.githubusercontent.com/serpro69/abc123/raw/file.txt"))
+	assert.False(t, IsGistURL("https://github.com/serpro69/capy/issues/44"))
+	assert.False(t, IsGistURL("https://docs.example.com"))
+	assert.False(t, IsGistURL(""))
+}
+
+func TestGhCommand(t *testing.T) {
+	t.Run("GitHub issue", func(t *testing.T) {
+		info := Info{Host: "github.com", Owner: "serpro69", Repo: "capy", Number: "44", Kind: "issue"}
+		assert.Equal(t, "gh issue view 44 --repo serpro69/capy", info.GhCommand())
+	})
+
+	t.Run("GitHub PR", func(t *testing.T) {
+		info := Info{Host: "github.com", Owner: "serpro69", Repo: "capy", Number: "47", Kind: "pr"}
+		assert.Equal(t, "gh pr view 47 --repo serpro69/capy", info.GhCommand())
+	})
+
+	t.Run("non-GitHub returns empty", func(t *testing.T) {
+		info := Info{Host: "gitlab.com", Number: "123", Kind: "issue"}
+		assert.Empty(t, info.GhCommand())
+	})
+}
+
+func TestKindDisplay(t *testing.T) {
+	assert.Equal(t, "issue", Info{Kind: "issue"}.KindDisplay())
+	assert.Equal(t, "pr", Info{Kind: "pr"}.KindDisplay())
+	assert.Equal(t, "merge request", Info{Kind: "mr"}.KindDisplay())
+}

--- a/internal/hook/gitplatform.go
+++ b/internal/hook/gitplatform.go
@@ -2,168 +2,68 @@ package hook
 
 import (
 	"fmt"
-	"net/url"
-	"strings"
+
+	"github.com/serpro69/capy/internal/giturl"
 )
 
-// gitURLInfo holds parsed information about a git platform issue/PR URL.
-type gitURLInfo struct {
-	Host   string // e.g. "github.com", "gitlab.com", "gitea.example.com"
-	Owner  string // populated for GitHub; may be empty for other platforms
-	Repo   string // populated for GitHub; may be empty for other platforms
-	Number string // issue/PR/MR number
-	Kind   string // "issue", "pr", or "mr"
+// gitPlatformBlockMessage returns a block reason when capy_fetch_and_index is
+// called with a git platform issue/PR/MR URL. Returns empty string for
+// non-matching URLs (gists, generic pages) where the tool should proceed.
+func gitPlatformBlockMessage(rawURL string) string {
+	info, ok := giturl.ParsePlatformURL(rawURL)
+	if !ok {
+		return ""
+	}
+
+	if ghCmd := info.GhCommand(); ghCmd != "" {
+		return fmt.Sprintf(
+			"capy: Blocked — this is a GitHub %s. Use `%s` for full comprehension. "+
+				"capy_fetch_and_index BM25-fragments the content, losing sequential context.",
+			info.KindDisplay(), ghCmd,
+		)
+	}
+
+	return fmt.Sprintf(
+		"capy: Blocked — this URL points to a %s (#%s). "+
+			"Use your platform's CLI or WebSearch for full comprehension. "+
+			"capy_fetch_and_index BM25-fragments the content, losing sequential context.",
+		info.KindDisplay(), info.Number,
+	)
 }
 
-// parseGitPlatformURL detects if a URL points to a git platform issue, PR, or
-// merge request. Recognizes GitHub, GitLab, Bitbucket, Gitea, and generic
-// platforms using common path conventions (/issues/N, /pull/N, /merge_requests/N).
-func parseGitPlatformURL(rawURL string) (info gitURLInfo, ok bool) {
-	u, err := url.Parse(rawURL)
-	if err != nil || u.Host == "" {
-		return gitURLInfo{}, false
+// gistGuidance returns soft guidance (FormatAllow) for gist URLs.
+// Gists can be large, so this is advisory rather than blocking.
+func gistGuidance(rawURL string) string {
+	if !giturl.IsGistURL(rawURL) {
+		return ""
 	}
-
-	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	info.Host = u.Host
-
-	// GitHub: owner/repo/issues/N or owner/repo/pull/N
-	if u.Host == "github.com" && len(parts) >= 4 {
-		info.Owner = parts[0]
-		info.Repo = parts[1]
-		switch parts[2] {
-		case "issues":
-			info.Number = parts[3]
-			info.Kind = "issue"
-			return info, true
-		case "pull":
-			info.Number = parts[3]
-			info.Kind = "pr"
-			return info, true
-		}
-	}
-
-	// Generic: scan for issue/PR markers at any path position.
-	// Covers GitLab (/-/issues/N, /-/merge_requests/N), Bitbucket
-	// (/issues/N, /pull-requests/N), Gitea (/issues/N, /pulls/N), and others.
-	for i := 0; i < len(parts)-1; i++ {
-		switch parts[i] {
-		case "issues":
-			info.Number = parts[i+1]
-			info.Kind = "issue"
-			return info, true
-		case "pull", "pulls", "pull-requests":
-			info.Number = parts[i+1]
-			info.Kind = "pr"
-			return info, true
-		case "merge_requests":
-			info.Number = parts[i+1]
-			info.Kind = "mr"
-			return info, true
-		}
-	}
-
-	return gitURLInfo{}, false
-}
-
-// isGistURL returns true for gist.github.com and gist.githubusercontent.com URLs.
-func isGistURL(rawURL string) bool {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return false
-	}
-	return u.Host == "gist.github.com" || u.Host == "gist.githubusercontent.com"
-}
-
-// fetchGuidance returns comprehension guidance when capy_fetch_and_index is
-// called with a git platform issue/PR/MR or gist URL. Returns empty string
-// for URLs where capy_fetch_and_index is the correct tool.
-func fetchGuidance(rawURL string) string {
-	info, ok := parseGitPlatformURL(rawURL)
-	if ok {
-		// GitHub-specific: suggest exact gh command
-		if info.Host == "github.com" && info.Owner != "" {
-			switch info.Kind {
-			case "issue":
-				return fmt.Sprintf(`<context_guidance>
-  <tip>
-    This URL points to a GitHub issue. For full comprehension, use:
-      gh issue view %s --repo %s/%s
-    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
-    Proceeding with fetch — but the gh command gives you the complete issue with comments.
-  </tip>
-</context_guidance>`, info.Number, info.Owner, info.Repo)
-			case "pr":
-				return fmt.Sprintf(`<context_guidance>
-  <tip>
-    This URL points to a GitHub PR. For full comprehension, use:
-      gh pr view %s --repo %s/%s
-    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
-    Proceeding with fetch — but the gh command gives you the complete PR with review comments.
-  </tip>
-</context_guidance>`, info.Number, info.Owner, info.Repo)
-			}
-		}
-
-		// Generic git platform: suggest alternatives without platform-specific CLI
-		kindName := info.Kind
-		if kindName == "mr" {
-			kindName = "merge request"
-		}
-		return fmt.Sprintf(`<context_guidance>
-  <tip>
-    This URL points to a git platform %s (#%s). For full comprehension, use your
-    platform's CLI or WebSearch — these are small authoritative pages.
-    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
-    Proceeding with fetch — but a direct tool gives you the complete content.
-  </tip>
-</context_guidance>`, kindName, info.Number)
-	}
-
-	if isGistURL(rawURL) {
-		return `<context_guidance>
+	return `<context_guidance>
   <tip>
     This URL points to a GitHub gist. For small gists needing full comprehension,
     consider using gh gist view or direct web tools first.
     capy_fetch_and_index is appropriate for large gists where you only need extracted facts.
   </tip>
 </context_guidance>`
-	}
-
-	return ""
 }
 
 // webFetchBlockMessage returns the block message for WebFetch calls, with
 // git-platform-specific comprehension guidance when the URL matches.
 func webFetchBlockMessage(rawURL string) string {
-	info, ok := parseGitPlatformURL(rawURL)
+	info, ok := giturl.ParsePlatformURL(rawURL)
 	if ok {
-		// GitHub-specific: suggest exact gh command
-		if info.Host == "github.com" && info.Owner != "" {
-			var ghCmd string
-			switch info.Kind {
-			case "issue":
-				ghCmd = fmt.Sprintf("gh issue view %s --repo %s/%s", info.Number, info.Owner, info.Repo)
-			case "pr":
-				ghCmd = fmt.Sprintf("gh pr view %s --repo %s/%s", info.Number, info.Owner, info.Repo)
-			}
+		if ghCmd := info.GhCommand(); ghCmd != "" {
 			return fmt.Sprintf(
 				"capy: WebFetch blocked. This is a GitHub %s — use `%s` for full comprehension. "+
 					"If you need searchable extraction of large content, use capy_fetch_and_index(url: %q) then capy_search(queries: [...]).",
-				info.Kind, ghCmd, rawURL,
+				info.KindDisplay(), ghCmd, rawURL,
 			)
 		}
 
-		// Generic git platform
-		kindName := info.Kind
-		if kindName == "mr" {
-			kindName = "merge request"
-		}
 		return fmt.Sprintf(
 			"capy: WebFetch blocked. This URL points to a %s (#%s). "+
 				"For full comprehension, use your platform's CLI or WebSearch. "+
 				"For large content extraction, use capy_fetch_and_index(url: %q) then capy_search(queries: [...]).",
-			kindName, info.Number, rawURL,
+			info.KindDisplay(), info.Number, rawURL,
 		)
 	}
 

--- a/internal/hook/gitplatform.go
+++ b/internal/hook/gitplatform.go
@@ -1,0 +1,175 @@
+package hook
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// gitURLInfo holds parsed information about a git platform issue/PR URL.
+type gitURLInfo struct {
+	Host   string // e.g. "github.com", "gitlab.com", "gitea.example.com"
+	Owner  string // populated for GitHub; may be empty for other platforms
+	Repo   string // populated for GitHub; may be empty for other platforms
+	Number string // issue/PR/MR number
+	Kind   string // "issue", "pr", or "mr"
+}
+
+// parseGitPlatformURL detects if a URL points to a git platform issue, PR, or
+// merge request. Recognizes GitHub, GitLab, Bitbucket, Gitea, and generic
+// platforms using common path conventions (/issues/N, /pull/N, /merge_requests/N).
+func parseGitPlatformURL(rawURL string) (info gitURLInfo, ok bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return gitURLInfo{}, false
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	info.Host = u.Host
+
+	// GitHub: owner/repo/issues/N or owner/repo/pull/N
+	if u.Host == "github.com" && len(parts) >= 4 {
+		info.Owner = parts[0]
+		info.Repo = parts[1]
+		switch parts[2] {
+		case "issues":
+			info.Number = parts[3]
+			info.Kind = "issue"
+			return info, true
+		case "pull":
+			info.Number = parts[3]
+			info.Kind = "pr"
+			return info, true
+		}
+	}
+
+	// Generic: scan for issue/PR markers at any path position.
+	// Covers GitLab (/-/issues/N, /-/merge_requests/N), Bitbucket
+	// (/issues/N, /pull-requests/N), Gitea (/issues/N, /pulls/N), and others.
+	for i := 0; i < len(parts)-1; i++ {
+		switch parts[i] {
+		case "issues":
+			info.Number = parts[i+1]
+			info.Kind = "issue"
+			return info, true
+		case "pull", "pulls", "pull-requests":
+			info.Number = parts[i+1]
+			info.Kind = "pr"
+			return info, true
+		case "merge_requests":
+			info.Number = parts[i+1]
+			info.Kind = "mr"
+			return info, true
+		}
+	}
+
+	return gitURLInfo{}, false
+}
+
+// isGistURL returns true for gist.github.com and gist.githubusercontent.com URLs.
+func isGistURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return u.Host == "gist.github.com" || u.Host == "gist.githubusercontent.com"
+}
+
+// fetchGuidance returns comprehension guidance when capy_fetch_and_index is
+// called with a git platform issue/PR/MR or gist URL. Returns empty string
+// for URLs where capy_fetch_and_index is the correct tool.
+func fetchGuidance(rawURL string) string {
+	info, ok := parseGitPlatformURL(rawURL)
+	if ok {
+		// GitHub-specific: suggest exact gh command
+		if info.Host == "github.com" && info.Owner != "" {
+			switch info.Kind {
+			case "issue":
+				return fmt.Sprintf(`<context_guidance>
+  <tip>
+    This URL points to a GitHub issue. For full comprehension, use:
+      gh issue view %s --repo %s/%s
+    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
+    Proceeding with fetch — but the gh command gives you the complete issue with comments.
+  </tip>
+</context_guidance>`, info.Number, info.Owner, info.Repo)
+			case "pr":
+				return fmt.Sprintf(`<context_guidance>
+  <tip>
+    This URL points to a GitHub PR. For full comprehension, use:
+      gh pr view %s --repo %s/%s
+    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
+    Proceeding with fetch — but the gh command gives you the complete PR with review comments.
+  </tip>
+</context_guidance>`, info.Number, info.Owner, info.Repo)
+			}
+		}
+
+		// Generic git platform: suggest alternatives without platform-specific CLI
+		kindName := info.Kind
+		if kindName == "mr" {
+			kindName = "merge request"
+		}
+		return fmt.Sprintf(`<context_guidance>
+  <tip>
+    This URL points to a git platform %s (#%s). For full comprehension, use your
+    platform's CLI or WebSearch — these are small authoritative pages.
+    capy_fetch_and_index will BM25-fragment the content, losing sequential context.
+    Proceeding with fetch — but a direct tool gives you the complete content.
+  </tip>
+</context_guidance>`, kindName, info.Number)
+	}
+
+	if isGistURL(rawURL) {
+		return `<context_guidance>
+  <tip>
+    This URL points to a GitHub gist. For small gists needing full comprehension,
+    consider using gh gist view or direct web tools first.
+    capy_fetch_and_index is appropriate for large gists where you only need extracted facts.
+  </tip>
+</context_guidance>`
+	}
+
+	return ""
+}
+
+// webFetchBlockMessage returns the block message for WebFetch calls, with
+// git-platform-specific comprehension guidance when the URL matches.
+func webFetchBlockMessage(rawURL string) string {
+	info, ok := parseGitPlatformURL(rawURL)
+	if ok {
+		// GitHub-specific: suggest exact gh command
+		if info.Host == "github.com" && info.Owner != "" {
+			var ghCmd string
+			switch info.Kind {
+			case "issue":
+				ghCmd = fmt.Sprintf("gh issue view %s --repo %s/%s", info.Number, info.Owner, info.Repo)
+			case "pr":
+				ghCmd = fmt.Sprintf("gh pr view %s --repo %s/%s", info.Number, info.Owner, info.Repo)
+			}
+			return fmt.Sprintf(
+				"capy: WebFetch blocked. This is a GitHub %s — use `%s` for full comprehension. "+
+					"If you need searchable extraction of large content, use capy_fetch_and_index(url: %q) then capy_search(queries: [...]).",
+				info.Kind, ghCmd, rawURL,
+			)
+		}
+
+		// Generic git platform
+		kindName := info.Kind
+		if kindName == "mr" {
+			kindName = "merge request"
+		}
+		return fmt.Sprintf(
+			"capy: WebFetch blocked. This URL points to a %s (#%s). "+
+				"For full comprehension, use your platform's CLI or WebSearch. "+
+				"For large content extraction, use capy_fetch_and_index(url: %q) then capy_search(queries: [...]).",
+			kindName, info.Number, rawURL,
+		)
+	}
+
+	return fmt.Sprintf(
+		"capy: WebFetch blocked. For comprehension of small pages, use WebSearch or direct tools (e.g., platform CLI for git issues/PRs). "+
+			"For large content extraction, use capy_fetch_and_index(url: %q) then capy_search(queries: [...]).",
+		rawURL,
+	)
+}

--- a/internal/hook/gitplatform_test.go
+++ b/internal/hook/gitplatform_test.go
@@ -1,0 +1,314 @@
+package hook
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitPlatformURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantHost   string
+		wantOwner  string
+		wantRepo   string
+		wantNumber string
+		wantKind   string
+		wantOK     bool
+	}{
+		{
+			name:       "GitHub issue",
+			url:        "https://github.com/serpro69/capy/issues/44",
+			wantHost:   "github.com",
+			wantOwner:  "serpro69",
+			wantRepo:   "capy",
+			wantNumber: "44",
+			wantKind:   "issue",
+			wantOK:     true,
+		},
+		{
+			name:       "GitHub PR",
+			url:        "https://github.com/serpro69/capy/pull/47",
+			wantHost:   "github.com",
+			wantOwner:  "serpro69",
+			wantRepo:   "capy",
+			wantNumber: "47",
+			wantKind:   "pr",
+			wantOK:     true,
+		},
+		{
+			name:       "GitHub issue with fragment",
+			url:        "https://github.com/serpro69/capy/issues/44#issuecomment-123",
+			wantHost:   "github.com",
+			wantOwner:  "serpro69",
+			wantRepo:   "capy",
+			wantNumber: "44",
+			wantKind:   "issue",
+			wantOK:     true,
+		},
+		{
+			name:       "GitHub PR with subpath",
+			url:        "https://github.com/serpro69/capy/pull/47/files",
+			wantHost:   "github.com",
+			wantOwner:  "serpro69",
+			wantRepo:   "capy",
+			wantNumber: "47",
+			wantKind:   "pr",
+			wantOK:     true,
+		},
+		{
+			name:       "GitLab issue",
+			url:        "https://gitlab.com/group/project/-/issues/123",
+			wantHost:   "gitlab.com",
+			wantNumber: "123",
+			wantKind:   "issue",
+			wantOK:     true,
+		},
+		{
+			name:       "GitLab merge request",
+			url:        "https://gitlab.com/group/project/-/merge_requests/456",
+			wantHost:   "gitlab.com",
+			wantNumber: "456",
+			wantKind:   "mr",
+			wantOK:     true,
+		},
+		{
+			name:       "Bitbucket pull request",
+			url:        "https://bitbucket.org/team/repo/pull-requests/78",
+			wantHost:   "bitbucket.org",
+			wantNumber: "78",
+			wantKind:   "pr",
+			wantOK:     true,
+		},
+		{
+			name:       "Gitea issue",
+			url:        "https://gitea.example.com/org/repo/issues/99",
+			wantHost:   "gitea.example.com",
+			wantNumber: "99",
+			wantKind:   "issue",
+			wantOK:     true,
+		},
+		{
+			name:       "Gitea pull",
+			url:        "https://gitea.example.com/org/repo/pulls/12",
+			wantHost:   "gitea.example.com",
+			wantNumber: "12",
+			wantKind:   "pr",
+			wantOK:     true,
+		},
+		{
+			name:   "GitHub repo root — not an issue or PR",
+			url:    "https://github.com/serpro69/capy",
+			wantOK: false,
+		},
+		{
+			name:   "GitHub issues listing — no number",
+			url:    "https://github.com/serpro69/capy/issues",
+			wantOK: false,
+		},
+		{
+			name:   "gist URL — not an issue or PR",
+			url:    "https://gist.github.com/serpro69/abc123",
+			wantOK: false,
+		},
+		{
+			name:   "non-git URL",
+			url:    "https://docs.example.com/api/reference",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			url:    "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, ok := parseGitPlatformURL(tt.url)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantHost, info.Host)
+				assert.Equal(t, tt.wantOwner, info.Owner)
+				assert.Equal(t, tt.wantRepo, info.Repo)
+				assert.Equal(t, tt.wantNumber, info.Number)
+				assert.Equal(t, tt.wantKind, info.Kind)
+			}
+		})
+	}
+}
+
+func TestIsGistURL(t *testing.T) {
+	assert.True(t, isGistURL("https://gist.github.com/serpro69/abc123"))
+	assert.True(t, isGistURL("https://gist.githubusercontent.com/serpro69/abc123/raw/file.txt"))
+	assert.False(t, isGistURL("https://github.com/serpro69/capy/issues/44"))
+	assert.False(t, isGistURL("https://docs.example.com"))
+	assert.False(t, isGistURL(""))
+}
+
+func TestFetchGuidance(t *testing.T) {
+	t.Run("GitHub issue URL returns guidance with gh issue view", func(t *testing.T) {
+		guidance := fetchGuidance("https://github.com/serpro69/capy/issues/44")
+		assert.Contains(t, guidance, "gh issue view 44 --repo serpro69/capy")
+		assert.Contains(t, guidance, "BM25-fragment")
+	})
+
+	t.Run("GitHub PR URL returns guidance with gh pr view", func(t *testing.T) {
+		guidance := fetchGuidance("https://github.com/serpro69/capy/pull/47")
+		assert.Contains(t, guidance, "gh pr view 47 --repo serpro69/capy")
+		assert.Contains(t, guidance, "BM25-fragment")
+	})
+
+	t.Run("GitLab issue returns generic guidance", func(t *testing.T) {
+		guidance := fetchGuidance("https://gitlab.com/group/project/-/issues/123")
+		assert.Contains(t, guidance, "issue")
+		assert.Contains(t, guidance, "#123")
+		assert.Contains(t, guidance, "platform")
+		assert.NotContains(t, guidance, "gh issue view")
+	})
+
+	t.Run("GitLab MR returns generic guidance", func(t *testing.T) {
+		guidance := fetchGuidance("https://gitlab.com/group/project/-/merge_requests/456")
+		assert.Contains(t, guidance, "merge request")
+		assert.Contains(t, guidance, "#456")
+	})
+
+	t.Run("gist URL returns softer guidance", func(t *testing.T) {
+		guidance := fetchGuidance("https://gist.github.com/serpro69/abc123")
+		assert.Contains(t, guidance, "gist")
+		assert.Contains(t, guidance, "gh gist view")
+		assert.NotContains(t, guidance, "gh issue view")
+	})
+
+	t.Run("generic URL returns empty string", func(t *testing.T) {
+		guidance := fetchGuidance("https://docs.example.com/api/reference")
+		assert.Empty(t, guidance)
+	})
+}
+
+func TestWebFetchBlockMessage(t *testing.T) {
+	t.Run("GitHub issue URL mentions gh issue view", func(t *testing.T) {
+		msg := webFetchBlockMessage("https://github.com/serpro69/capy/issues/44")
+		assert.Contains(t, msg, "gh issue view 44 --repo serpro69/capy")
+		assert.Contains(t, msg, "GitHub issue")
+	})
+
+	t.Run("GitHub PR URL mentions gh pr view", func(t *testing.T) {
+		msg := webFetchBlockMessage("https://github.com/serpro69/capy/pull/47")
+		assert.Contains(t, msg, "gh pr view 47 --repo serpro69/capy")
+		assert.Contains(t, msg, "GitHub pr")
+	})
+
+	t.Run("GitLab issue mentions platform CLI", func(t *testing.T) {
+		msg := webFetchBlockMessage("https://gitlab.com/group/project/-/issues/123")
+		assert.Contains(t, msg, "issue")
+		assert.Contains(t, msg, "#123")
+		assert.Contains(t, msg, "platform")
+		assert.NotContains(t, msg, "gh issue view")
+	})
+
+	t.Run("generic URL mentions WebSearch and comprehension", func(t *testing.T) {
+		msg := webFetchBlockMessage("https://docs.example.com/page")
+		assert.Contains(t, msg, "WebSearch")
+		assert.Contains(t, msg, "capy_fetch_and_index")
+		assert.NotContains(t, msg, "gh issue view")
+	})
+}
+
+func TestFetchAndIndexGitGuidanceHook(t *testing.T) {
+	a := &testAdapter{}
+
+	t.Run("GitHub issue URL produces FormatAllow guidance", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/issues/44"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "context", resp["action"])
+		ctx, _ := resp["additionalContext"].(string)
+		assert.Contains(t, ctx, "gh issue view 44 --repo serpro69/capy")
+	})
+
+	t.Run("GitHub PR URL produces FormatAllow guidance", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/pull/47"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "context", resp["action"])
+		ctx, _ := resp["additionalContext"].(string)
+		assert.Contains(t, ctx, "gh pr view 47 --repo serpro69/capy")
+	})
+
+	t.Run("GitLab MR URL produces FormatAllow guidance", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://gitlab.com/group/project/-/merge_requests/456"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "context", resp["action"])
+		ctx, _ := resp["additionalContext"].(string)
+		assert.Contains(t, ctx, "merge request")
+		assert.Contains(t, ctx, "#456")
+	})
+
+	t.Run("generic URL passes through with no guidance", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://docs.example.com/large-api-reference"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("WebFetch with GitHub issue URL mentions gh in block message", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "WebFetch",
+			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/issues/44"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "deny", resp["action"])
+		reason, _ := resp["reason"].(string)
+		assert.Contains(t, reason, "gh issue view 44 --repo serpro69/capy")
+	})
+
+	t.Run("WebFetch with generic URL gives comprehension guidance", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "WebFetch",
+			"tool_input": map[string]any{"url": "https://docs.example.com/page"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "deny", resp["action"])
+		reason, _ := resp["reason"].(string)
+		assert.Contains(t, reason, "WebSearch")
+	})
+}

--- a/internal/hook/gitplatform_test.go
+++ b/internal/hook/gitplatform_test.go
@@ -8,184 +8,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseGitPlatformURL(t *testing.T) {
-	tests := []struct {
-		name       string
-		url        string
-		wantHost   string
-		wantOwner  string
-		wantRepo   string
-		wantNumber string
-		wantKind   string
-		wantOK     bool
-	}{
-		{
-			name:       "GitHub issue",
-			url:        "https://github.com/serpro69/capy/issues/44",
-			wantHost:   "github.com",
-			wantOwner:  "serpro69",
-			wantRepo:   "capy",
-			wantNumber: "44",
-			wantKind:   "issue",
-			wantOK:     true,
-		},
-		{
-			name:       "GitHub PR",
-			url:        "https://github.com/serpro69/capy/pull/47",
-			wantHost:   "github.com",
-			wantOwner:  "serpro69",
-			wantRepo:   "capy",
-			wantNumber: "47",
-			wantKind:   "pr",
-			wantOK:     true,
-		},
-		{
-			name:       "GitHub issue with fragment",
-			url:        "https://github.com/serpro69/capy/issues/44#issuecomment-123",
-			wantHost:   "github.com",
-			wantOwner:  "serpro69",
-			wantRepo:   "capy",
-			wantNumber: "44",
-			wantKind:   "issue",
-			wantOK:     true,
-		},
-		{
-			name:       "GitHub PR with subpath",
-			url:        "https://github.com/serpro69/capy/pull/47/files",
-			wantHost:   "github.com",
-			wantOwner:  "serpro69",
-			wantRepo:   "capy",
-			wantNumber: "47",
-			wantKind:   "pr",
-			wantOK:     true,
-		},
-		{
-			name:       "GitLab issue",
-			url:        "https://gitlab.com/group/project/-/issues/123",
-			wantHost:   "gitlab.com",
-			wantNumber: "123",
-			wantKind:   "issue",
-			wantOK:     true,
-		},
-		{
-			name:       "GitLab merge request",
-			url:        "https://gitlab.com/group/project/-/merge_requests/456",
-			wantHost:   "gitlab.com",
-			wantNumber: "456",
-			wantKind:   "mr",
-			wantOK:     true,
-		},
-		{
-			name:       "Bitbucket pull request",
-			url:        "https://bitbucket.org/team/repo/pull-requests/78",
-			wantHost:   "bitbucket.org",
-			wantNumber: "78",
-			wantKind:   "pr",
-			wantOK:     true,
-		},
-		{
-			name:       "Gitea issue",
-			url:        "https://gitea.example.com/org/repo/issues/99",
-			wantHost:   "gitea.example.com",
-			wantNumber: "99",
-			wantKind:   "issue",
-			wantOK:     true,
-		},
-		{
-			name:       "Gitea pull",
-			url:        "https://gitea.example.com/org/repo/pulls/12",
-			wantHost:   "gitea.example.com",
-			wantNumber: "12",
-			wantKind:   "pr",
-			wantOK:     true,
-		},
-		{
-			name:   "GitHub repo root — not an issue or PR",
-			url:    "https://github.com/serpro69/capy",
-			wantOK: false,
-		},
-		{
-			name:   "GitHub issues listing — no number",
-			url:    "https://github.com/serpro69/capy/issues",
-			wantOK: false,
-		},
-		{
-			name:   "gist URL — not an issue or PR",
-			url:    "https://gist.github.com/serpro69/abc123",
-			wantOK: false,
-		},
-		{
-			name:   "non-git URL",
-			url:    "https://docs.example.com/api/reference",
-			wantOK: false,
-		},
-		{
-			name:   "empty string",
-			url:    "",
-			wantOK: false,
-		},
-	}
+func TestGitPlatformBlockMessage(t *testing.T) {
+	t.Run("GitHub issue URL returns block with gh issue view", func(t *testing.T) {
+		msg := gitPlatformBlockMessage("https://github.com/serpro69/capy/issues/44")
+		assert.Contains(t, msg, "gh issue view 44 --repo serpro69/capy")
+		assert.Contains(t, msg, "Blocked")
+		assert.Contains(t, msg, "BM25-fragment")
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			info, ok := parseGitPlatformURL(tt.url)
-			assert.Equal(t, tt.wantOK, ok)
-			if ok {
-				assert.Equal(t, tt.wantHost, info.Host)
-				assert.Equal(t, tt.wantOwner, info.Owner)
-				assert.Equal(t, tt.wantRepo, info.Repo)
-				assert.Equal(t, tt.wantNumber, info.Number)
-				assert.Equal(t, tt.wantKind, info.Kind)
-			}
-		})
-	}
+	t.Run("GitHub PR URL returns block with gh pr view", func(t *testing.T) {
+		msg := gitPlatformBlockMessage("https://github.com/serpro69/capy/pull/47")
+		assert.Contains(t, msg, "gh pr view 47 --repo serpro69/capy")
+		assert.Contains(t, msg, "Blocked")
+	})
+
+	t.Run("GitLab issue returns generic block", func(t *testing.T) {
+		msg := gitPlatformBlockMessage("https://gitlab.com/group/project/-/issues/123")
+		assert.Contains(t, msg, "issue")
+		assert.Contains(t, msg, "#123")
+		assert.Contains(t, msg, "platform")
+		assert.NotContains(t, msg, "gh issue view")
+	})
+
+	t.Run("gist URL returns empty (not blocked)", func(t *testing.T) {
+		assert.Empty(t, gitPlatformBlockMessage("https://gist.github.com/serpro69/abc123"))
+	})
+
+	t.Run("generic URL returns empty (not blocked)", func(t *testing.T) {
+		assert.Empty(t, gitPlatformBlockMessage("https://docs.example.com/api/reference"))
+	})
 }
 
-func TestIsGistURL(t *testing.T) {
-	assert.True(t, isGistURL("https://gist.github.com/serpro69/abc123"))
-	assert.True(t, isGistURL("https://gist.githubusercontent.com/serpro69/abc123/raw/file.txt"))
-	assert.False(t, isGistURL("https://github.com/serpro69/capy/issues/44"))
-	assert.False(t, isGistURL("https://docs.example.com"))
-	assert.False(t, isGistURL(""))
-}
-
-func TestFetchGuidance(t *testing.T) {
-	t.Run("GitHub issue URL returns guidance with gh issue view", func(t *testing.T) {
-		guidance := fetchGuidance("https://github.com/serpro69/capy/issues/44")
-		assert.Contains(t, guidance, "gh issue view 44 --repo serpro69/capy")
-		assert.Contains(t, guidance, "BM25-fragment")
-	})
-
-	t.Run("GitHub PR URL returns guidance with gh pr view", func(t *testing.T) {
-		guidance := fetchGuidance("https://github.com/serpro69/capy/pull/47")
-		assert.Contains(t, guidance, "gh pr view 47 --repo serpro69/capy")
-		assert.Contains(t, guidance, "BM25-fragment")
-	})
-
-	t.Run("GitLab issue returns generic guidance", func(t *testing.T) {
-		guidance := fetchGuidance("https://gitlab.com/group/project/-/issues/123")
-		assert.Contains(t, guidance, "issue")
-		assert.Contains(t, guidance, "#123")
-		assert.Contains(t, guidance, "platform")
-		assert.NotContains(t, guidance, "gh issue view")
-	})
-
-	t.Run("GitLab MR returns generic guidance", func(t *testing.T) {
-		guidance := fetchGuidance("https://gitlab.com/group/project/-/merge_requests/456")
-		assert.Contains(t, guidance, "merge request")
-		assert.Contains(t, guidance, "#456")
-	})
-
-	t.Run("gist URL returns softer guidance", func(t *testing.T) {
-		guidance := fetchGuidance("https://gist.github.com/serpro69/abc123")
+func TestGistGuidance(t *testing.T) {
+	t.Run("gist URL returns soft guidance", func(t *testing.T) {
+		guidance := gistGuidance("https://gist.github.com/serpro69/abc123")
 		assert.Contains(t, guidance, "gist")
 		assert.Contains(t, guidance, "gh gist view")
-		assert.NotContains(t, guidance, "gh issue view")
 	})
 
-	t.Run("generic URL returns empty string", func(t *testing.T) {
-		guidance := fetchGuidance("https://docs.example.com/api/reference")
-		assert.Empty(t, guidance)
+	t.Run("non-gist URL returns empty", func(t *testing.T) {
+		assert.Empty(t, gistGuidance("https://github.com/serpro69/capy/issues/44"))
+		assert.Empty(t, gistGuidance("https://docs.example.com"))
 	})
 }
 
@@ -199,7 +62,6 @@ func TestWebFetchBlockMessage(t *testing.T) {
 	t.Run("GitHub PR URL mentions gh pr view", func(t *testing.T) {
 		msg := webFetchBlockMessage("https://github.com/serpro69/capy/pull/47")
 		assert.Contains(t, msg, "gh pr view 47 --repo serpro69/capy")
-		assert.Contains(t, msg, "GitHub pr")
 	})
 
 	t.Run("GitLab issue mentions platform CLI", func(t *testing.T) {
@@ -207,82 +69,21 @@ func TestWebFetchBlockMessage(t *testing.T) {
 		assert.Contains(t, msg, "issue")
 		assert.Contains(t, msg, "#123")
 		assert.Contains(t, msg, "platform")
-		assert.NotContains(t, msg, "gh issue view")
 	})
 
-	t.Run("generic URL mentions WebSearch and comprehension", func(t *testing.T) {
+	t.Run("generic URL mentions WebSearch", func(t *testing.T) {
 		msg := webFetchBlockMessage("https://docs.example.com/page")
 		assert.Contains(t, msg, "WebSearch")
 		assert.Contains(t, msg, "capy_fetch_and_index")
-		assert.NotContains(t, msg, "gh issue view")
 	})
 }
 
-func TestFetchAndIndexGitGuidanceHook(t *testing.T) {
+func TestFetchAndIndexHookBehavior(t *testing.T) {
 	a := &testAdapter{}
 
-	t.Run("GitHub issue URL produces FormatAllow guidance", func(t *testing.T) {
+	t.Run("GitHub issue URL produces FormatBlock", func(t *testing.T) {
 		input, _ := json.Marshal(map[string]any{
 			"tool_name":  "capy_fetch_and_index",
-			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/issues/44"},
-		})
-		result, err := handlePreToolUse(input, a, nil, "/tmp")
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(result, &resp))
-		assert.Equal(t, "context", resp["action"])
-		ctx, _ := resp["additionalContext"].(string)
-		assert.Contains(t, ctx, "gh issue view 44 --repo serpro69/capy")
-	})
-
-	t.Run("GitHub PR URL produces FormatAllow guidance", func(t *testing.T) {
-		input, _ := json.Marshal(map[string]any{
-			"tool_name":  "capy_fetch_and_index",
-			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/pull/47"},
-		})
-		result, err := handlePreToolUse(input, a, nil, "/tmp")
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(result, &resp))
-		assert.Equal(t, "context", resp["action"])
-		ctx, _ := resp["additionalContext"].(string)
-		assert.Contains(t, ctx, "gh pr view 47 --repo serpro69/capy")
-	})
-
-	t.Run("GitLab MR URL produces FormatAllow guidance", func(t *testing.T) {
-		input, _ := json.Marshal(map[string]any{
-			"tool_name":  "capy_fetch_and_index",
-			"tool_input": map[string]any{"url": "https://gitlab.com/group/project/-/merge_requests/456"},
-		})
-		result, err := handlePreToolUse(input, a, nil, "/tmp")
-		require.NoError(t, err)
-		require.NotNil(t, result)
-
-		var resp map[string]any
-		require.NoError(t, json.Unmarshal(result, &resp))
-		assert.Equal(t, "context", resp["action"])
-		ctx, _ := resp["additionalContext"].(string)
-		assert.Contains(t, ctx, "merge request")
-		assert.Contains(t, ctx, "#456")
-	})
-
-	t.Run("generic URL passes through with no guidance", func(t *testing.T) {
-		input, _ := json.Marshal(map[string]any{
-			"tool_name":  "capy_fetch_and_index",
-			"tool_input": map[string]any{"url": "https://docs.example.com/large-api-reference"},
-		})
-		result, err := handlePreToolUse(input, a, nil, "/tmp")
-		require.NoError(t, err)
-		assert.Nil(t, result)
-	})
-
-	t.Run("WebFetch with GitHub issue URL mentions gh in block message", func(t *testing.T) {
-		input, _ := json.Marshal(map[string]any{
-			"tool_name":  "WebFetch",
 			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/issues/44"},
 		})
 		result, err := handlePreToolUse(input, a, nil, "/tmp")
@@ -296,10 +97,10 @@ func TestFetchAndIndexGitGuidanceHook(t *testing.T) {
 		assert.Contains(t, reason, "gh issue view 44 --repo serpro69/capy")
 	})
 
-	t.Run("WebFetch with generic URL gives comprehension guidance", func(t *testing.T) {
+	t.Run("GitHub PR URL produces FormatBlock", func(t *testing.T) {
 		input, _ := json.Marshal(map[string]any{
-			"tool_name":  "WebFetch",
-			"tool_input": map[string]any{"url": "https://docs.example.com/page"},
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/pull/47"},
 		})
 		result, err := handlePreToolUse(input, a, nil, "/tmp")
 		require.NoError(t, err)
@@ -309,6 +110,62 @@ func TestFetchAndIndexGitGuidanceHook(t *testing.T) {
 		require.NoError(t, json.Unmarshal(result, &resp))
 		assert.Equal(t, "deny", resp["action"])
 		reason, _ := resp["reason"].(string)
-		assert.Contains(t, reason, "WebSearch")
+		assert.Contains(t, reason, "gh pr view 47 --repo serpro69/capy")
+	})
+
+	t.Run("GitLab MR URL produces FormatBlock", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://gitlab.com/group/project/-/merge_requests/456"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "deny", resp["action"])
+		reason, _ := resp["reason"].(string)
+		assert.Contains(t, reason, "merge request")
+	})
+
+	t.Run("gist URL produces FormatAllow (soft guidance)", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://gist.github.com/serpro69/abc123"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "context", resp["action"])
+	})
+
+	t.Run("generic URL passes through", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "capy_fetch_and_index",
+			"tool_input": map[string]any{"url": "https://docs.example.com/large-api-reference"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("WebFetch with GitHub issue URL mentions gh", func(t *testing.T) {
+		input, _ := json.Marshal(map[string]any{
+			"tool_name":  "WebFetch",
+			"tool_input": map[string]any{"url": "https://github.com/serpro69/capy/issues/44"},
+		})
+		result, err := handlePreToolUse(input, a, nil, "/tmp")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "deny", resp["action"])
+		reason, _ := resp["reason"].(string)
+		assert.Contains(t, reason, "gh issue view 44 --repo serpro69/capy")
 	})
 }

--- a/internal/hook/pretooluse.go
+++ b/internal/hook/pretooluse.go
@@ -37,11 +37,10 @@ func handlePreToolUse(input []byte, a adapter.HookAdapter, policies []security.S
 		return routeBash(command, policies, a, projectDir, sessionID)
 	}
 
-	// ─── WebFetch: deny → redirect to sandbox ───
+	// ─── WebFetch: deny → redirect with comprehension-aware guidance ───
 	if canonical == "WebFetch" {
 		url, _ := toolInput["url"].(string)
-		reason := fmt.Sprintf("capy: WebFetch blocked. Use capy_fetch_and_index(url: %q) to fetch this URL in sandbox. Then use capy_search(queries: [...]) to query results.", url)
-		return a.FormatBlock(reason)
+		return a.FormatBlock(webFetchBlockMessage(url))
 	}
 
 	// ─── Read: guidance once ───
@@ -139,48 +138,51 @@ func routeAgent(toolInput map[string]any, a adapter.HookAdapter) ([]byte, error)
 	return a.FormatModify(updated)
 }
 
-// routeCapyTool runs security checks on capy MCP tools.
+// routeCapyTool runs security checks and routing guidance on capy MCP tools.
 func routeCapyTool(toolName string, toolInput map[string]any, policies []security.SecurityPolicy, projectDir string, a adapter.HookAdapter) ([]byte, error) {
-	if len(policies) == 0 {
-		return nil, nil
-	}
-
-	// Determine which tool variant we're dealing with
-	switch {
-	case strings.HasSuffix(toolName, "execute") && !strings.HasSuffix(toolName, "batch_execute"):
-		// capy_execute: check shell code against deny policies
-		lang, _ := toolInput["language"].(string)
-		if lang == "shell" {
-			code, _ := toolInput["code"].(string)
-			return checkCommandSecurity(code, policies, a)
-		}
-
-	case strings.HasSuffix(toolName, "execute_file"):
-		// capy_execute_file: check file path + shell code
-		filePath, _ := toolInput["path"].(string)
-		if filePath != "" {
-			denyGlobs := security.ReadToolDenyPatterns("Read", projectDir, "")
-			denied, pattern := security.EvaluateFilePath(filePath, denyGlobs)
-			if denied {
-				return a.FormatBlock(fmt.Sprintf("Blocked by security policy: file path matches Read deny pattern %s", pattern))
+	// Security checks (only when policies exist)
+	if len(policies) > 0 {
+		switch {
+		case strings.HasSuffix(toolName, "execute") && !strings.HasSuffix(toolName, "batch_execute"):
+			lang, _ := toolInput["language"].(string)
+			if lang == "shell" {
+				code, _ := toolInput["code"].(string)
+				return checkCommandSecurity(code, policies, a)
 			}
-		}
-		lang, _ := toolInput["language"].(string)
-		if lang == "shell" {
-			code, _ := toolInput["code"].(string)
-			return checkCommandSecurity(code, policies, a)
-		}
 
-	case strings.HasSuffix(toolName, "batch_execute"):
-		// capy_batch_execute: check each command
-		commands, _ := toolInput["commands"].([]any)
-		for _, entry := range commands {
-			if m, ok := entry.(map[string]any); ok {
-				cmd, _ := m["command"].(string)
-				if result, err := checkCommandSecurity(cmd, policies, a); result != nil || err != nil {
-					return result, err
+		case strings.HasSuffix(toolName, "execute_file"):
+			filePath, _ := toolInput["path"].(string)
+			if filePath != "" {
+				denyGlobs := security.ReadToolDenyPatterns("Read", projectDir, "")
+				denied, pattern := security.EvaluateFilePath(filePath, denyGlobs)
+				if denied {
+					return a.FormatBlock(fmt.Sprintf("Blocked by security policy: file path matches Read deny pattern %s", pattern))
 				}
 			}
+			lang, _ := toolInput["language"].(string)
+			if lang == "shell" {
+				code, _ := toolInput["code"].(string)
+				return checkCommandSecurity(code, policies, a)
+			}
+
+		case strings.HasSuffix(toolName, "batch_execute"):
+			commands, _ := toolInput["commands"].([]any)
+			for _, entry := range commands {
+				if m, ok := entry.(map[string]any); ok {
+					cmd, _ := m["command"].(string)
+					if result, err := checkCommandSecurity(cmd, policies, a); result != nil || err != nil {
+						return result, err
+					}
+				}
+			}
+		}
+	}
+
+	// GitHub URL comprehension guidance for fetch_and_index (fires every call, not once-per-session)
+	if strings.HasSuffix(toolName, "fetch_and_index") {
+		url, _ := toolInput["url"].(string)
+		if guidance := fetchGuidance(url); guidance != "" {
+			return a.FormatAllow(guidance)
 		}
 	}
 

--- a/internal/hook/pretooluse.go
+++ b/internal/hook/pretooluse.go
@@ -178,10 +178,13 @@ func routeCapyTool(toolName string, toolInput map[string]any, policies []securit
 		}
 	}
 
-	// GitHub URL comprehension guidance for fetch_and_index (fires every call, not once-per-session)
+	// Git platform URL enforcement for fetch_and_index (fires every call)
 	if strings.HasSuffix(toolName, "fetch_and_index") {
 		url, _ := toolInput["url"].(string)
-		if guidance := fetchGuidance(url); guidance != "" {
+		if msg := gitPlatformBlockMessage(url); msg != "" {
+			return a.FormatBlock(msg)
+		}
+		if guidance := gistGuidance(url); guidance != "" {
 			return a.FormatAllow(guidance)
 		}
 	}

--- a/internal/hook/routing.go
+++ b/internal/hook/routing.go
@@ -32,8 +32,7 @@ func RoutingBlock() string {
   <blocked>
     - curl/wget in Bash → use capy_fetch_and_index or capy_execute
     - Inline HTTP in Bash → use capy_execute
-    - WebFetch → use capy_fetch_and_index
-    Note: For web comprehension, use runtime-native tools (gh, WebSearch) when available
+    - WebFetch → for git issues/PRs/MRs: platform CLI (gh issue view) or WebSearch; for large content: capy_fetch_and_index
   </blocked>
 
   <output_constraints>

--- a/internal/platform/routing.go
+++ b/internal/platform/routing.go
@@ -58,11 +58,10 @@ Instead use:
 - ` + "`capy_execute(language, code)`" + ` to run HTTP calls in sandbox — only stdout enters context
 
 ### WebFetch — BLOCKED
-WebFetch calls are denied entirely. The URL is extracted and you are told to use ` + "`capy_fetch_and_index`" + ` instead.
-Instead use:
-- ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + ` to query the indexed content
-
-**Note:** These blocks prevent raw HTTP output from flooding context. For web *comprehension* of small authoritative pages, use runtime-native tools when available (` + "`gh`" + ` CLI for GitHub content, ` + "`WebSearch`" + ` for general queries). ` + "`capy_fetch_and_index`" + ` remains the correct path for large web content and extraction.
+WebFetch calls are denied entirely. Instead use:
+- For git platform issues/PRs/MRs: platform CLI (e.g., ` + "`gh issue view N`" + `) or ` + "`WebSearch`" + ` for full comprehension
+- For other small pages needing comprehension: ` + "`WebSearch`" + ` or other runtime web tools
+- For large web content or extraction: ` + "`capy_fetch_and_index(url, source)`" + ` then ` + "`capy_search(queries)`" + `
 
 ## Source kinds
 

--- a/internal/platform/routing_test.go
+++ b/internal/platform/routing_test.go
@@ -61,8 +61,12 @@ func TestRoutingBlockWebComprehension(t *testing.T) {
 		"routing block should mention authoritative web pages for comprehension")
 	assert.Contains(t, block, "runtime web tools",
 		"routing block should reference runtime web tools as alternative")
-	assert.Contains(t, block, "web comprehension",
-		"routing block blocked section should mention web comprehension alternative")
+
+	// WebFetch redirect must split comprehension vs extraction paths (issue #49)
+	assert.Contains(t, block, "git issues/PRs/MRs",
+		"routing block should route git platform URLs to direct tools")
+	assert.Contains(t, block, "gh issue view",
+		"routing block should mention gh CLI as example")
 }
 
 func TestCapyToolNamesComplete(t *testing.T) {

--- a/internal/server/tool_fetch.go
+++ b/internal/server/tool_fetch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/commonmark"
 	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/serpro69/capy/internal/giturl"
 	"github.com/serpro69/capy/internal/store"
 )
 
@@ -54,6 +55,13 @@ func (s *Server) handleFetchAndIndex(_ context.Context, req mcp.CallToolRequest)
 	// SSRF protection: block requests to local/private networks
 	if err := validateFetchURLFunc(url); err != nil {
 		return errorResult(fmt.Sprintf("Blocked URL: %v", err)), nil
+	}
+
+	// Git platform issue/PR/MR URLs should use platform CLI for comprehension,
+	// not BM25-fragmented indexing. Block at the server level so this works for
+	// ALL MCP clients (Claude Code, Codex, Cursor, etc.), not just those running hooks.
+	if info, ok := giturl.ParsePlatformURL(url); ok {
+		return s.trackToolResponse("capy_fetch_and_index", textResult(gitPlatformRedirectMessage(info))), nil
 	}
 
 	label := source
@@ -271,6 +279,22 @@ func isBinaryContent(contentType string, body []byte) bool {
 	}
 
 	return false
+}
+
+// gitPlatformRedirectMessage returns the redirect text when capy_fetch_and_index
+// is called with a git platform issue/PR/MR URL.
+func gitPlatformRedirectMessage(info giturl.Info) string {
+	alternative := "your platform's CLI or WebSearch"
+	if ghCmd := info.GhCommand(); ghCmd != "" {
+		alternative = "`" + ghCmd + "`"
+	}
+
+	return fmt.Sprintf(
+		"**Not fetched** — this URL points to a %s (#%s).\n\n"+
+			"For full comprehension, use %s instead.\n"+
+			"capy_fetch_and_index BM25-fragments content, losing sequential context.",
+		info.KindDisplay(), info.Number, alternative,
+	)
 }
 
 // formatAge formats a duration as a human-readable age string.

--- a/internal/server/tools.go
+++ b/internal/server/tools.go
@@ -211,7 +211,7 @@ func toolSearch() mcp.Tool {
 func toolFetchAndIndex() mcp.Tool {
 	return mcp.NewTool("capy_fetch_and_index",
 		mcp.WithToolAnnotation(annotationFetch),
-		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Best for large web artifacts where you need extracted facts or follow-up searchable context. For small authoritative pages (issues, PRs, specs) you need to comprehend fully, prefer runtime-native tools (gh CLI, WebSearch) when available. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
+		mcp.WithDescription("Fetches URL content, converts HTML to markdown, indexes as ephemeral (24h TTL, excluded from default search), and returns a ~3KB preview. Best for large web artifacts where you need extracted facts or follow-up searchable context. DO NOT use for git platform issues/PRs/MRs you need to comprehend fully — use platform CLI (e.g., gh issue view / gh pr view) or WebSearch instead. Use source: filter or include_kinds for follow-up search. Pass kind: 'durable' for reference docs you want to persist across sessions. Content-type aware: HTML→markdown, JSON→chunked by key paths, text→indexed directly."),
 		mcp.WithString("url",
 			mcp.Required(),
 			mcp.Description("The URL to fetch and index"),


### PR DESCRIPTION
- (fix) Add hook-level friction for git platform URLs in capy_fetch_and_index (#49)
  Guidance-only routing was insufficient — models knew the rule but
  competing signals (URL → URL tool, WebFetch blocked → use capy_fetch)
  won at decision time. This adds mechanical enforcement:
  - Hook intercepts capy_fetch_and_index calls with git issue/PR/MR URLs
    and injects per-call comprehension guidance (FormatAllow, not block)
  - WebFetch block message now splits comprehension vs extraction paths
  - URL detection is platform-generic (GitHub, GitLab, Bitbucket, Gitea)
    with GitHub-specific gh CLI suggestions
  - Routing text and tool description strengthened across all surfaces
- (fix) Server-side enforcement for git platform URLs in capy_fetch_and_index (#49)
  Guidance-only routing was insufficient — models had the rule but
  competing mechanical signals won at decision time, and client-side
  hooks don't fire in all runtimes (Codex bypasses PreToolUse).
  - Server-side block in handleFetchAndIndex: detects git issue/PR/MR
    URLs and returns redirect message without fetching. Works for all
    MCP clients.
  - Hook upgraded from FormatAllow to FormatBlock for git URLs
    (belt-and-suspenders for Claude Code)
  - Shared internal/giturl package for platform-generic URL detection
  - Gists keep soft guidance (FormatAllow) — legitimate extraction targets
  - ADR-024 documents the decision chain from #44 → #47 → #49