### PR TITLE
(fix) Align sweep dry-run classification with --force mtime logic (#55)

### DIFF
--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -69,7 +69,7 @@ func runSweepDryRun(st *store.ContentStore, projectDir string, opts session.Swee
 	fmt.Printf("%-38s %8s %5s %5s %8s  %s\n", "UUID", "SIZE", "PAIRS", "MAIN", "CHARS", "STATUS")
 	fmt.Println("-----------------------------------------------------------------------------------------------")
 
-	var indexable, alreadyIndexed, notIndexable, parseErrors int
+	var indexable, alreadyIndexed, stale, notIndexable, parseErrors int
 	for _, d := range results {
 		status := sweepStatus(d)
 		fmt.Printf("%-38s %8s %5d %5d %8d  %s\n",
@@ -80,6 +80,8 @@ func runSweepDryRun(st *store.ContentStore, projectDir string, opts session.Swee
 			parseErrors++
 		case d.AlreadyIndexed:
 			alreadyIndexed++
+		case d.Stale:
+			stale++
 		case d.Indexable:
 			indexable++
 		default:
@@ -87,11 +89,11 @@ func runSweepDryRun(st *store.ContentStore, projectDir string, opts session.Swee
 		}
 	}
 
-	fmt.Printf("\nTotal: %d | Indexable: %d | Already indexed: %d | Not indexable: %d | Errors: %d\n",
-		len(results), indexable, alreadyIndexed, notIndexable, parseErrors)
+	fmt.Printf("\nTotal: %d | Indexable: %d | Stale: %d | Already indexed: %d | Not indexable: %d | Errors: %d\n",
+		len(results), indexable, stale, alreadyIndexed, notIndexable, parseErrors)
 
-	if indexable > 0 {
-		fmt.Println("\nUse --force to index the indexable sessions.")
+	if indexable+stale > 0 {
+		fmt.Println("\nUse --force to index the indexable/stale sessions.")
 	}
 
 	return nil
@@ -115,6 +117,9 @@ func sweepStatus(d session.SessionDiagnostic) string {
 	}
 	if d.AlreadyIndexed {
 		return "already indexed"
+	}
+	if d.Stale {
+		return "stale (modified since last index)"
 	}
 	if d.Indexable {
 		return "indexable"

--- a/internal/session/sweep.go
+++ b/internal/session/sweep.go
@@ -70,6 +70,7 @@ type SessionDiagnostic struct {
 	AssistantChars int
 	Indexable      bool
 	AlreadyIndexed bool
+	Stale          bool // indexed before but file modified since — will be re-indexed
 	ParseError     string
 }
 
@@ -106,7 +107,11 @@ func DryRunSweep(projectDir string, cs *store.ContentStore, opts SweepOptions) (
 
 		if !opts.Reindex && indexedMap != nil {
 			if _, exists := indexedMap[uuid]; exists {
-				d.AlreadyIndexed = true
+				if shouldSkip(dir, uuid, e, indexedMap) {
+					d.AlreadyIndexed = true
+				} else {
+					d.Stale = true
+				}
 			}
 		}
 

--- a/internal/session/sweep_test.go
+++ b/internal/session/sweep_test.go
@@ -765,6 +765,14 @@ func TestDryRunSweep_AlreadyIndexed(t *testing.T) {
 		t.Fatalf("indexSession failed: %v", err)
 	}
 
+	// Set file mtime to the past so it appears unchanged relative to indexed_at
+	// (indexed_at has second precision; file mtime has nanosecond precision).
+	pastTime := time.Now().Add(-time.Minute)
+	jsonlPath := filepath.Join(sessionDir, "sess-indexed.jsonl")
+	if err := os.Chtimes(jsonlPath, pastTime, pastTime); err != nil {
+		t.Fatal(err)
+	}
+
 	results, err := DryRunSweep(projectDir, cs, SweepOptions{})
 	if err != nil {
 		t.Fatalf("DryRunSweep failed: %v", err)
@@ -776,6 +784,26 @@ func TestDryRunSweep_AlreadyIndexed(t *testing.T) {
 
 	if !results[0].AlreadyIndexed {
 		t.Error("expected session to be marked as already indexed")
+	}
+	if results[0].Stale {
+		t.Error("unchanged session should not be marked as stale")
+	}
+
+	// Touch the file to make it newer than indexed_at → should be stale, not already indexed.
+	futureTime := time.Now().Add(time.Hour)
+	if err := os.Chtimes(jsonlPath, futureTime, futureTime); err != nil {
+		t.Fatal(err)
+	}
+
+	staleResults, err := DryRunSweep(projectDir, cs, SweepOptions{})
+	if err != nil {
+		t.Fatalf("DryRunSweep (stale check) failed: %v", err)
+	}
+	if staleResults[0].AlreadyIndexed {
+		t.Error("stale session should not be marked as already indexed")
+	}
+	if !staleResults[0].Stale {
+		t.Error("session modified after indexing should be marked as stale")
 	}
 
 	// With Reindex, should NOT be marked as already indexed.


### PR DESCRIPTION
DryRunSweep checked only UUID presence to mark sessions as "already
indexed", ignoring file mtime. SweepWithOptions compared mtime against
indexed_at, causing sessions modified after indexing to show as
"already indexed" in dry-run but get re-indexed under --force.

Now DryRunSweep calls shouldSkip for mtime-aware classification and
surfaces a new "stale" status for sessions that will be re-indexed.