### PR TITLE
Share the knowledge DB across git worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Architecture Decision Records are in [docs/adr/](docs/adr/). Key ones:
 - ADR-023: Fetch ephemeral default and routing rewrite
 - ADR-024: Server-side git URL enforcement
 - ADR-025: Vault `index_version` and DB-driven reindex
+- ADR-026: Git worktrees share the main worktree's knowledge DB
 
 ## Completed Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,6 +361,14 @@ capy uses TOML configuration with three-level precedence (lowest to highest):
 # log_level = "info"                # "debug", "info", "warn", "error"
 ```
 
+**Worktree DB resolution** (see ADR-026): with a relative (project-scoped)
+`store.path`, a session running in a linked git worktree resolves the DB against
+the repository's **main** worktree, so all worktrees share one committed
+`.capy/knowledge.db`. `config.MainWorktreeDir` detects this by parsing the
+worktree's `.git` file (no `git` subprocess; submodules excluded), falling back to
+the current directory on any unexpected layout. Absolute `store.path` and the XDG
+default are unaffected.
+
 ## Releases
 
 Releases are fully automated. Push a semver tag to trigger the pipeline:

--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ capy serve         # DB opens with your key
 
 The pre-commit hook rejects unencrypted databases automatically — run `capy encrypt` first if the commit is blocked.
 
+> **Git worktrees.** With a project-scoped `store.path`, sessions running in a [git
+> worktree](https://git-scm.com/docs/git-worktree) automatically use the **main**
+> worktree's DB instead of a per-worktree copy — so worktree knowledge persists to
+> the shared `.capy/knowledge.db` and never produces an unresolvable binary merge
+> conflict. Detection reads the worktree's `.git` file directly (no `git` required).
+> Absolute paths and the XDG default are unaffected. See [ADR-026](docs/adr/026-worktree-shared-knowledge-db.md).
+
 ### Key rotation
 
 ```bash

--- a/cmd/capy/checkpoint.go
+++ b/cmd/capy/checkpoint.go
@@ -48,7 +48,7 @@ has the DB open, the WAL cannot be fully truncated.`,
 			// We don't use ContentStore here because:
 			// 1. NewContentStore is lazy — Close() would no-op on an unopened store
 			// 2. database/sql's connection pool can interfere with checkpoint
-			st := store.NewContentStore(dbPath, projectDir, 0, 0)
+			st := store.NewContentStore(dbPath, cfg.DBProjectDir(projectDir), 0, 0)
 			if err := st.Checkpoint(); err != nil {
 				return fmt.Errorf("checkpoint failed: %w", err)
 			}

--- a/cmd/capy/cleanup.go
+++ b/cmd/capy/cleanup.go
@@ -41,7 +41,7 @@ func newCleanupCmd() *cobra.Command {
 			vacuum, _ := cmd.Flags().GetBool("vacuum")
 
 			dbPath := cfg.ResolveDBPath(projectDir)
-			st := store.NewContentStore(dbPath, projectDir, 0, cfg.Store.MaxSourceBytes)
+			st := store.NewContentStore(dbPath, cfg.DBProjectDir(projectDir), 0, cfg.Store.MaxSourceBytes)
 			defer st.Close()
 
 			// Explicit vacuum without cleanup.

--- a/cmd/capy/dbsize.go
+++ b/cmd/capy/dbsize.go
@@ -24,7 +24,7 @@ func newDBSizeCmd() *cobra.Command {
 			}
 
 			dbPath := cfg.ResolveDBPath(projectDir)
-			st := store.NewContentStore(dbPath, projectDir, 0, 0)
+			st := store.NewContentStore(dbPath, cfg.DBProjectDir(projectDir), 0, 0)
 			defer st.Close()
 
 			breakdown, err := st.DiskUsage()

--- a/cmd/capy/sweep.go
+++ b/cmd/capy/sweep.go
@@ -41,7 +41,7 @@ func newSweepCmd() *cobra.Command {
 			opts := session.SweepOptions{Reindex: reindex}
 
 			dbPath := cfg.ResolveDBPath(projectDir)
-			st := store.NewContentStore(dbPath, projectDir, 0, 0)
+			st := store.NewContentStore(dbPath, cfg.DBProjectDir(projectDir), 0, 0)
 			defer st.Close()
 
 			if force {

--- a/docs/adr/026-worktree-shared-knowledge-db.md
+++ b/docs/adr/026-worktree-shared-knowledge-db.md
@@ -1,0 +1,126 @@
+# ADR-026: Git worktrees share the main worktree's knowledge DB
+
+**Status:** Accepted
+**Date:** 2026-06-16
+
+## Context
+
+[ADR-019](019-encrypted-knowledge-db.md) re-enabled committing the (now
+encrypted) knowledge DB to git via an opt-in project-scoped `store.path`
+(e.g. `store.path = ".capy/knowledge.db"`), superseding [ADR-015](015-knowledge-db-not-tracked-in-git.md)'s
+blanket prohibition. The documented cross-machine workflow (README §Cross-machine
+sync) is: configure a project-local `store.path`, `capy encrypt` → `capy
+checkpoint` → commit `.capy/knowledge.db`.
+
+That committed-DB setup breaks under [git worktrees](https://git-scm.com/docs/git-worktree).
+A linked worktree is a separate working directory checked out from the same
+repository. With a project-scoped `store.path`, capy resolved the DB relative to
+the worktree's own root, so each worktree got its **own copy** of
+`.capy/knowledge.db`:
+
+- Knowledge indexed during a worktree session lands in the worktree's copy and is
+  **stranded** — it never reaches the main project's DB.
+- Because `knowledge.db` is a committed **binary** file, two worktrees writing
+  their own copies produce a merge conflict with **no resolvable diff**. The
+  practical outcome is that worktree DB changes are discarded.
+
+Net effect: there is no way to persist knowledge from sessions that happen in a
+worktree. We want a worktree session to read and write the *same* DB as the main
+checkout, transparently.
+
+The XDG default path (`~/.local/share/capy/<project-hash>/knowledge.db`) has the
+same per-worktree *separation* (the hash is keyed off the worktree path), but
+**not** the same pain: it is outside git, so nothing is committed and nothing
+conflicts. The acute, data-losing problem is specific to a project-scoped
+(relative) `store.path`.
+
+## Decision
+
+### D1: Redirect a project-scoped DB to the repository's main worktree
+
+`config.DBProjectDir(projectDir)` is the single point that decides which project
+directory owns the knowledge DB:
+
+- **Relative `store.path`** (project-scoped) **in a linked worktree** → the
+  repository's **main worktree**. All worktrees of a repo therefore share one DB,
+  which lives in (and is committed from) the main checkout.
+- **Absolute `store.path`** → unchanged. It is already a fixed, shared location.
+- **XDG default** (empty `store.path`) → unchanged. Keyed per project, not
+  committed, so per-worktree separation causes no conflict (see Consequences for
+  the deliberate scope limit).
+
+`ResolveDBPath` resolves a relative `store.path` against `DBProjectDir(projectDir)`
+instead of the raw `projectDir`.
+
+### D2: Detect the main worktree by parsing `.git`, not by shelling out to git
+
+`config.MainWorktreeDir(projectDir)` identifies a linked worktree **without
+invoking the `git` binary** and **without relying on any committed marker file**:
+
+1. `<projectDir>/.git` is a regular **file** (a directory means a normal repo or
+   the main worktree itself → no redirect).
+2. The file contains `gitdir: <worktree git dir>`; that git dir must sit under
+   `…/worktrees/<name>`. This segment guard is what distinguishes a worktree from
+   a **submodule** (whose `.git` file also points via `gitdir:`, but into
+   `…/.git/modules/<name>`) — a submodule must keep its own DB.
+3. The common git dir is read from the worktree git dir's `commondir` file
+   (fallback: strip the trailing `worktrees/<name>` segments); the main worktree
+   is its parent.
+
+Reading the `.git` file directly is faster (no subprocess on every startup),
+works even when `git` is not on `PATH`, and is more robust than a committed
+`.capy/.project` marker — which would record a machine-specific absolute path and
+is gitignored and overwritten per worktree. Any malformed or unexpected layout
+**falls back to `projectDir`** (fail-safe): a detection failure forgoes the
+redirect but never breaks DB resolution.
+
+### D3: The `.capy/.project` marker records the DB owner, not the working dir
+
+`internal/store/store.go` writes a diagnostic `.capy/.project` marker next to the
+DB recording the store's `projectDir`. That marker has **no code readers** — it is
+write-only. Because the DB now lives under the main worktree, all five production
+`store.NewContentStore` call sites (`server.go`, and `cmd/capy/{cleanup,sweep,checkpoint,dbsize}.go`)
+pass `DBProjectDir(projectDir)` so the marker records the **main** worktree (the
+DB's true owner) rather than clobbering it with the current worktree's path.
+
+This is deliberately decoupled from the *working* directory. The MCP server's own
+`s.projectDir` — used for security globs, the executor working directory, and
+session sweep — stays the **current** worktree, because file operations are
+worktree-local. Only DB ownership follows the main worktree.
+
+## Consequences
+
+- A worktree session with a project-scoped `store.path` transparently reads and
+  writes the main checkout's `.capy/knowledge.db`. Worktree knowledge persists and
+  the binary-merge-conflict failure mode is eliminated.
+- `capy which`, `capy cleanup`, `capy sweep`, `capy checkpoint`, and `capy dbsize`
+  run from a worktree all operate on the main worktree's DB automatically.
+- **Scope limit (deliberate):** the XDG default is *not* redirected — worktrees
+  keep separate XDG-hashed DBs. They do not conflict (outside git), but worktree
+  knowledge is also not shared back to the main project in that mode. Sharing the
+  XDG default across worktrees was considered out of scope for the data-losing
+  problem this ADR targets; it can be revisited if users want it.
+- Submodules are explicitly excluded by the `worktrees/<name>` segment guard, so a
+  submodule checkout keeps its own DB.
+- Cross-worktree concurrency uses the same single-DB story as any two capy
+  processes sharing a DB — SQLite WAL handles concurrent access; the
+  WAL-checkpoint-on-close invariant ([ADR-016](016-wal-mode-and-checkpoint-strategy.md))
+  is unchanged.
+
+## Alternatives considered
+
+### Shell out to `git rev-parse --git-common-dir` (rejected)
+Correct, but spawns a `git` subprocess on every server/CLI startup and requires
+`git` on `PATH`. Parsing the `.git` file yields the same answer with neither cost.
+
+### Read a committed `.capy/.project` marker to find the main worktree (rejected)
+The marker stores a machine-specific **absolute** path, is gitignored (so a
+worktree checkout would not even receive it), and is overwritten per worktree —
+circular and non-portable. Git's own worktree metadata is the authoritative,
+machine-correct source.
+
+### Redirect the XDG default too (deferred)
+Would make every worktree share the main project's hashed DB. Out of scope: the
+XDG default does not lose data (no commit, no conflict), and redirecting it would
+change behavior for all worktree users — including any who rely on per-worktree
+isolation. Left for a follow-up if demand appears.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,6 +304,15 @@ Three-level precedence (lowest to highest):
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full config reference.
 
+**DB path resolution** (`config.ResolveDBPath`): an absolute `store.path` is used
+verbatim; a relative `store.path` is resolved against the project directory; an
+empty `store.path` falls back to the XDG default
+`~/.local/share/capy/<project-hash>/knowledge.db`. For a relative (project-scoped)
+`store.path`, a session running inside a linked **git worktree** resolves the DB
+against the repository's **main worktree** so all worktrees share one committed DB
+(`config.MainWorktreeDir` / `config.DBProjectDir`; submodules excluded). See
+[ADR-026](adr/026-worktree-shared-knowledge-db.md).
+
 ## CLI Commands
 
 | Command | Description |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -330,6 +330,103 @@ func TestResolveDBPathAbsolute(t *testing.T) {
 	assert.Equal(t, "/custom/path/knowledge.db", path)
 }
 
+// makeLinkedWorktree builds a fake git linked-worktree layout on disk and
+// returns the main worktree dir and the linked worktree dir. When withCommondir
+// is false, the worktree's git dir omits the "commondir" file to exercise the
+// segment-stripping fallback.
+func makeLinkedWorktree(t *testing.T, withCommondir bool) (mainDir, wtDir string) {
+	t.Helper()
+	root := t.TempDir()
+	mainDir = filepath.Join(root, "main")
+	wtDir = filepath.Join(root, "wt")
+	wtGitDir := filepath.Join(mainDir, ".git", "worktrees", "wt")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(mainDir, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(wtGitDir, 0o755))
+	require.NoError(t, os.MkdirAll(wtDir, 0o755))
+
+	// A linked worktree's .git is a file pointing at its git dir.
+	require.NoError(t, os.WriteFile(filepath.Join(wtDir, ".git"),
+		[]byte("gitdir: "+wtGitDir+"\n"), 0o644))
+
+	if withCommondir {
+		require.NoError(t, os.WriteFile(filepath.Join(wtGitDir, "commondir"),
+			[]byte("../..\n"), 0o644))
+	}
+	return mainDir, wtDir
+}
+
+func TestMainWorktreeDir_NotAWorktree(t *testing.T) {
+	// No .git at all → returned unchanged.
+	dir := t.TempDir()
+	assert.Equal(t, dir, MainWorktreeDir(dir))
+
+	// .git is a directory (normal repo / main worktree) → returned unchanged.
+	repo := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	assert.Equal(t, repo, MainWorktreeDir(repo))
+}
+
+func TestMainWorktreeDir_LinkedWorktree(t *testing.T) {
+	mainDir, wtDir := makeLinkedWorktree(t, true)
+	assert.Equal(t, mainDir, MainWorktreeDir(wtDir))
+}
+
+func TestMainWorktreeDir_LinkedWorktreeNoCommondir(t *testing.T) {
+	// Without a commondir file, resolution falls back to stripping the
+	// trailing "worktrees/<name>" segments from the git dir.
+	mainDir, wtDir := makeLinkedWorktree(t, false)
+	assert.Equal(t, mainDir, MainWorktreeDir(wtDir))
+}
+
+func TestMainWorktreeDir_GarbageGitFile(t *testing.T) {
+	// A .git file that is not a "gitdir:" pointer falls back to projectDir.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"),
+		[]byte("not a gitdir pointer\n"), 0o644))
+	assert.Equal(t, dir, MainWorktreeDir(dir))
+}
+
+func TestMainWorktreeDir_SubmoduleNotRedirected(t *testing.T) {
+	// A git submodule's .git is also a file, but its git dir lives under
+	// "modules/<name>", not "worktrees/<name>" — it must keep its own DB.
+	root := t.TempDir()
+	superDir := filepath.Join(root, "super")
+	subDir := filepath.Join(superDir, "sub")
+	subGitDir := filepath.Join(superDir, ".git", "modules", "sub")
+
+	require.NoError(t, os.MkdirAll(subGitDir, 0o755))
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, ".git"),
+		[]byte("gitdir: "+subGitDir+"\n"), 0o644))
+
+	assert.Equal(t, subDir, MainWorktreeDir(subDir))
+}
+
+func TestDBProjectDir_RelativePathRedirectsToMainWorktree(t *testing.T) {
+	mainDir, wtDir := makeLinkedWorktree(t, true)
+
+	cfg := DefaultConfig()
+	cfg.Store.Path = ".capy/knowledge.db"
+	// A worktree session resolves to the main worktree's DB...
+	assert.Equal(t, mainDir, cfg.DBProjectDir(wtDir))
+	// ...so the resolved DB path lives under the main worktree.
+	assert.Equal(t, filepath.Join(mainDir, ".capy/knowledge.db"), cfg.ResolveDBPath(wtDir))
+}
+
+func TestDBProjectDir_AbsoluteAndDefaultUnchanged(t *testing.T) {
+	_, wtDir := makeLinkedWorktree(t, true)
+
+	// Absolute store.path is already shared — no redirect.
+	abs := DefaultConfig()
+	abs.Store.Path = "/custom/knowledge.db"
+	assert.Equal(t, wtDir, abs.DBProjectDir(wtDir))
+
+	// XDG default (empty store.path) is keyed per project — no redirect.
+	def := DefaultConfig()
+	assert.Equal(t, wtDir, def.DBProjectDir(wtDir))
+}
+
 func TestEphemeralTTLHoursDefault(t *testing.T) {
 	cfg := DefaultConfig()
 	assert.Equal(t, 24, cfg.Store.Cleanup.EphemeralTTLHours)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -51,6 +51,76 @@ func DetectProjectRoot() string {
 	return cwd
 }
 
+// MainWorktreeDir returns the main worktree of the git repository that
+// contains projectDir. For a normal checkout, the main worktree itself, or a
+// non-git directory, it returns projectDir unchanged. For a linked git
+// worktree — identified by a .git that is a regular FILE rather than a
+// directory — it follows the file's "gitdir:" pointer to the common git
+// directory and returns that directory's parent.
+//
+// It never invokes git: the worktree layout is read directly from disk, which
+// is more robust than relying on a committed marker file and works even when
+// git is unavailable. Any malformed or unexpected layout falls back to
+// returning projectDir, so a failure to resolve never breaks DB path
+// resolution — it only forgoes the worktree redirect.
+func MainWorktreeDir(projectDir string) string {
+	dotGit := filepath.Join(projectDir, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil || info.IsDir() {
+		// No .git, or a normal repo / main worktree (.git is a directory).
+		return projectDir
+	}
+
+	// A linked worktree's .git is a file: "gitdir: <worktree git dir>".
+	data, err := os.ReadFile(dotGit)
+	if err != nil {
+		return projectDir
+	}
+	content := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(content, "gitdir:") {
+		return projectDir
+	}
+	gitDir := strings.TrimSpace(strings.TrimPrefix(content, "gitdir:"))
+	if gitDir == "" {
+		return projectDir
+	}
+	if !filepath.IsAbs(gitDir) {
+		// A relative gitdir is relative to the dir holding .git — always projectDir.
+		gitDir = filepath.Join(projectDir, gitDir)
+	}
+
+	// A linked worktree's git dir always lives at "<common>/worktrees/<name>".
+	// Anything else — most notably a submodule's "<super>/.git/modules/<name>" —
+	// is not a worktree and must keep its own database.
+	if filepath.Base(filepath.Dir(gitDir)) != "worktrees" {
+		return projectDir
+	}
+
+	main := filepath.Dir(commonGitDir(gitDir)) // parent of "<main>/.git"
+	if mainInfo, err := os.Stat(main); err != nil || !mainInfo.IsDir() {
+		return projectDir
+	}
+	return main
+}
+
+// commonGitDir resolves the shared (main) .git directory for a linked
+// worktree's git directory. Git records the relative path to the common
+// directory in a "commondir" file; when that is missing or empty it falls back
+// to stripping the trailing "worktrees/<name>" segments.
+func commonGitDir(worktreeGitDir string) string {
+	if data, err := os.ReadFile(filepath.Join(worktreeGitDir, "commondir")); err == nil {
+		rel := strings.TrimSpace(string(data))
+		if rel != "" {
+			if filepath.IsAbs(rel) {
+				return filepath.Clean(rel)
+			}
+			return filepath.Clean(filepath.Join(worktreeGitDir, rel))
+		}
+	}
+	// Fallback: "<common>/worktrees/<name>" -> "<common>".
+	return filepath.Dir(filepath.Dir(worktreeGitDir))
+}
+
 // ProjectHash returns a deterministic 16-hex-char hash of the absolute project path.
 func ProjectHash(dir string) string {
 	abs, _ := filepath.Abs(dir)
@@ -183,15 +253,30 @@ func unmangledProbe(prefix string, parts []string) string {
 	return ""
 }
 
+// DBProjectDir returns the project directory whose knowledge database the
+// session at projectDir should use. When store.path is project-scoped (a
+// relative path stored inside the project tree) and projectDir is a linked git
+// worktree, it returns the repository's main worktree so that every worktree
+// of a repo shares a single database (see issue #69 — a per-worktree copy of a
+// committed DB strands its writes and conflicts unresolvably on merge).
+// Absolute store paths are already shared, and the XDG default is keyed per
+// project, so both are returned unchanged.
+func (c *Config) DBProjectDir(projectDir string) string {
+	if c.Store.Path != "" && !filepath.IsAbs(c.Store.Path) {
+		return MainWorktreeDir(projectDir)
+	}
+	return projectDir
+}
+
 // ResolveDBPath returns the path to the SQLite knowledge base.
-// If Config.Store.Path is set, it is resolved relative to projectDir.
+// If Config.Store.Path is set, it is resolved relative to DBProjectDir(projectDir).
 // Otherwise, the default XDG data location is used.
 func (c *Config) ResolveDBPath(projectDir string) string {
 	if c.Store.Path != "" {
 		if filepath.IsAbs(c.Store.Path) {
 			return c.Store.Path
 		}
-		return filepath.Join(projectDir, c.Store.Path)
+		return filepath.Join(c.DBProjectDir(projectDir), c.Store.Path)
 	}
 
 	dataHome := os.Getenv("XDG_DATA_HOME")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,17 +47,17 @@ func (t *searchThrottle) advance(window time.Duration) (int, time.Duration) {
 
 // Server is the capy MCP server.
 type Server struct {
-	mcpServer      *mcpserver.MCPServer
-	store          *store.ContentStore
-	executor       *executor.PolyglotExecutor
-	security       []security.SecurityPolicy
-	readDenyGlobs  [][]string // cached Read deny patterns
-	config         *config.Config
-	stats          *SessionStats
-	throttle       *searchThrottle
-	storeMu        sync.Once
-	bgWg           sync.WaitGroup
-	projectDir     string
+	mcpServer     *mcpserver.MCPServer
+	store         *store.ContentStore
+	executor      *executor.PolyglotExecutor
+	security      []security.SecurityPolicy
+	readDenyGlobs [][]string // cached Read deny patterns
+	config        *config.Config
+	stats         *SessionStats
+	throttle      *searchThrottle
+	storeMu       sync.Once
+	bgWg          sync.WaitGroup
+	projectDir    string
 }
 
 // NewServer creates a new Server. The store is lazily initialized on first use.
@@ -82,7 +82,12 @@ func NewServer(
 func (s *Server) getStore() *store.ContentStore {
 	s.storeMu.Do(func() {
 		dbPath := s.config.ResolveDBPath(s.projectDir)
-		s.store = store.NewContentStore(dbPath, s.projectDir, s.config.Store.TitleWeight, s.config.Store.MaxSourceBytes)
+		s.store = store.NewContentStore(
+			dbPath,
+			s.config.DBProjectDir(s.projectDir),
+			s.config.Store.TitleWeight,
+			s.config.Store.MaxSourceBytes,
+		)
 	})
 	return s.store
 }


### PR DESCRIPTION
A project-scoped (relative) store.path resolved the knowledge DB relative
to the current working directory. In a linked git worktree that yielded a
separate copy of the committed .capy/knowledge.db: knowledge written in a
worktree session was stranded, and because the DB is a committed binary it
conflicted unresolvably on merge. There was effectively no way to persist
knowledge from sessions that run in a worktree.

Resolve a relative store.path against the repository's main worktree when
the session runs in a linked worktree, so every worktree of a repo shares
one DB. config.MainWorktreeDir detects this by parsing the worktree's .git
file directly (gitdir -> commondir -> main worktree): no git subprocess, no
reliance on a committed marker, and it works when git is off PATH. The
worktrees/<name> segment guard excludes submodules, and any unexpected
layout falls back to the current directory so detection never breaks DB
resolution.

config.DBProjectDir redirects only for a relative store.path; absolute
paths are already shared and the XDG default is uncommitted, so both are
left unchanged. All five store constructors pass DBProjectDir so the
write-only .capy/.project marker records the DB owner (the main worktree)
rather than clobbering it with the worktree path. The server's own
projectDir stays the current worktree for security globs, the executor
working directory, and session sweep.

Documented in ADR-026 with README, architecture, and CONTRIBUTING notes.

Closes #69

## Test Plan
make test