### PR TITLE
Add `capy cleanup --optimize` to reclaim FTS5 tombstone bloat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Architecture Decision Records are in [docs/adr/](docs/adr/). Key ones:
 - ADR-026: Git worktrees share the main worktree's knowledge DB
 - ADR-027: The vault is the sole session store (drop `session` writes from knowledge.db)
 - ADR-028: Corpus-agnostic retrieval core + cross-corpus RRF federation
+- ADR-029: FTS5 tombstone-bloat reclamation (`cleanup --optimize`)
 
 ## Completed Features
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ capy vault rekey                     # enter the OLD passphrase when prompted
 
 Global flags: `--project-dir`, `--version`
 
-Cleanup flags: `--max-age-days` (default 30), `--dry-run` (default true), `--force`
+Cleanup flags: `--dry-run` (default true), `--force`, `--kind` (`ephemeral`/`session`), `--source <label>`, `--vacuum` (reclaim freelist pages), `--optimize` (rebuild FTS indexes + VACUUM to reclaim FTS bloat that `--vacuum` alone cannot — see [ADR-029](docs/adr/029-fts-tombstone-bloat-reclamation.md))
 
 ### Shell Completions
 

--- a/cmd/capy/cleanup.go
+++ b/cmd/capy/cleanup.go
@@ -39,10 +39,26 @@ func newCleanupCmd() *cobra.Command {
 			}
 
 			vacuum, _ := cmd.Flags().GetBool("vacuum")
+			optimize, _ := cmd.Flags().GetBool("optimize")
 
 			dbPath := cfg.ResolveDBPath(projectDir)
 			st := store.NewContentStore(dbPath, cfg.DBProjectDir(projectDir), 0, cfg.Store.MaxSourceBytes)
 			defer st.Close()
+
+			// Explicit optimize without cleanup: rebuild the FTS indexes to
+			// release delete-tombstone segments, then VACUUM to reclaim the
+			// freed pages. A plain VACUUM cannot shrink these — the pages are
+			// held by the FTS5 data tables, not the freelist.
+			//
+			// The !force guard is deliberate: with --force the user asked to
+			// evict data too, so we skip this standalone path and let the run
+			// fall through to the cleanup + post-cleanup reclamation below.
+			if optimize && !force && sourceLabel == "" && kind == "" {
+				if err := reclaimFTS(st); err != nil {
+					return err
+				}
+				return nil
+			}
 
 			// Explicit vacuum without cleanup.
 			if vacuum && !force && sourceLabel == "" && kind == "" {
@@ -83,10 +99,16 @@ func newCleanupCmd() *cobra.Command {
 				return fmt.Errorf("cleanup failed: %w", err)
 			}
 
-			// Explicit --vacuum with --force: always vacuum after cleanup,
-			// regardless of freelist ratio (auto-vacuum may have already run
-			// inside Cleanup if ratio > 20%, but the user asked explicitly).
-			if vacuum && !dryRun {
+			// Explicit reclamation after cleanup. --optimize does the full
+			// FTS-rebuild + VACUUM (the only path that reclaims FTS bloat);
+			// --vacuum alone only compacts the freelist. --optimize supersedes
+			// --vacuum since it already vacuums.
+			switch {
+			case optimize && !dryRun:
+				if err := reclaimFTS(st); err != nil {
+					return err
+				}
+			case vacuum && !dryRun:
 				if err := st.Vacuum(); err != nil {
 					return fmt.Errorf("vacuum failed: %w", err)
 				}
@@ -122,7 +144,23 @@ func newCleanupCmd() *cobra.Command {
 	cmd.Flags().String("kind", "", "only clean up sources of this kind (\"ephemeral\" or \"session\")")
 	cmd.Flags().String("source", "", "evict a specific source by exact label")
 	cmd.Flags().Bool("vacuum", false, "run VACUUM to reclaim dead pages (auto-runs after cleanup when freelist > 20%%)")
+	cmd.Flags().Bool("optimize", false, "rebuild FTS indexes then VACUUM to reclaim FTS bloat that plain --vacuum cannot")
 	return cmd
+}
+
+// reclaimFTS rebuilds the FTS5 indexes and then VACUUMs, the only sequence that
+// reclaims disk pinned by accumulated FTS delete-tombstone segments (a plain
+// VACUUM leaves them because they belong to the FTS data tables, not the
+// freelist). Shared by the standalone --optimize path and the post-cleanup one.
+func reclaimFTS(st *store.ContentStore) error {
+	if err := st.RebuildFTS(); err != nil {
+		return fmt.Errorf("optimize failed: %w", err)
+	}
+	if err := st.Vacuum(); err != nil {
+		return fmt.Errorf("vacuum after optimize failed: %w", err)
+	}
+	fmt.Println("capy: optimize complete (FTS rebuilt, VACUUM reclaimed freed pages)")
+	return nil
 }
 
 // formatCleanupDetail renders per-source eviction detail, switching between

--- a/docs/adr/022-source-size-guard-and-db-bloat-prevention.md
+++ b/docs/adr/022-source-size-guard-and-db-bloat-prevention.md
@@ -64,6 +64,12 @@ After a non-dry-run cleanup that evicts at least one source, `Cleanup()` checks 
 
 An explicit `capy cleanup --vacuum` flag is also available for manual use.
 
+> **Note (ADR-029):** `VACUUM` only reclaims freelist pages. It cannot reclaim
+> FTS5 delete-tombstone segments, whose pages stay live in the FTS shadow
+> tables — a DB can sit at 50+ MB with a 0-page freelist. `capy cleanup
+> --optimize` rebuilds the FTS indexes (releasing those segments) and then
+> vacuums. See ADR-029.
+
 ### 6. `capy dbsize` diagnostic subcommand
 
 New CLI command showing table-level page counts, content-by-kind breakdown, top 15 sources by content size, freelist stats, and vocabulary size. Essential for diagnosing bloat and verifying cleanup results.

--- a/docs/adr/029-fts-tombstone-bloat-reclamation.md
+++ b/docs/adr/029-fts-tombstone-bloat-reclamation.md
@@ -1,0 +1,93 @@
+# ADR-029: FTS5 tombstone-bloat reclamation (`cleanup --optimize`)
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-022 bounded per-source index growth and added an auto-`VACUUM` pass after
+cleanup (§5). In practice a knowledge DB could still balloon to 50+ MB while
+holding under 1 MB of live content, and neither `capy cleanup --force` nor
+`capy cleanup --vacuum` reclaimed it. `capy dbsize` reported **0 freelist
+pages** — so `VACUUM`, which only compacts freelist pages, was a no-op.
+
+The bloat lives in the FTS5 index, not the freelist. capy indexes content into
+two FTS5 tables (`chunks`, `chunks_trigram`). When a source is evicted, FTS5
+does not free the underlying index pages — it appends *delete-tombstone
+segments*. Those pages remain **live** (owned by the FTS5 shadow data tables),
+so they never enter the freelist and `VACUUM` cannot touch them. Over months of
+index/evict churn (and, historically, session-transcript writes since dropped
+per ADR-027), the tombstone segments accumulate without bound.
+
+The incremental FTS5 `'optimize'` command that `optimizeFTS` already runs every
+50 inserts performs only a bounded segment merge; it does not fully discard the
+tombstones. Only a full FTS5 `'rebuild'` reconstructs the index from the content
+tables, releasing every stale segment page to the freelist — after which a
+`VACUUM` compacts the file.
+
+Measured on a real bloated DB: **50.9 MB → 8.3 MB**, all 83 sources intact.
+
+## Decision
+
+Add a `RebuildFTS()` store method and expose it as `capy cleanup --optimize`.
+
+1. **`RebuildFTS()`** runs `INSERT INTO chunks(chunks) VALUES('rebuild')` and the
+   same for `chunks_trigram` on a dedicated single connection (the same pattern
+   `Vacuum` and `Checkpoint` use), then checkpoints the WAL. Rebuild alone does
+   not shrink the file — it only moves the freed pages to the freelist.
+
+2. **`--optimize`** chains `RebuildFTS()` then `Vacuum()` (the sequence that
+   actually reclaims disk). It works standalone (`capy cleanup --optimize`) and
+   after a forced cleanup (`capy cleanup --force --optimize`), where it evicts
+   stale sources first and then reclaims. `--optimize` supersedes `--vacuum`
+   since it already vacuums.
+
+3. **Busy checkpoint is tolerated, not fatal.** The post-rebuild
+   `wal_checkpoint(TRUNCATE)` runs while the connection pool may still be open
+   (the `--force --optimize` path), so it can legitimately downgrade to PASSIVE
+   (`busy > 0`). This costs no reclamation — the subsequent `VACUUM` opens its
+   own connection and rewrites the full logical DB, WAL frames included — so
+   `RebuildFTS` logs a warning rather than erroring. This is the opposite of the
+   `Checkpoint()` method, which is only ever called with the pool closed and so
+   errors on `busy > 0`.
+
+4. **`--optimize` intentionally ignores the `--dry-run` default.** `cleanup`
+   defaults to dry-run, but reclamation is a maintenance operation, not data
+   eviction — mirroring the existing `--vacuum` flag. Gating it on dry-run would
+   make `capy cleanup --optimize` a silent no-op, the same trap that
+   `--kind session` cleanup produces without `--force`.
+
+## Consequences
+
+**Positive**
+
+- Users have a first-class, verified path to reclaim FTS bloat that `VACUUM`
+  alone cannot: `capy cleanup --optimize`.
+- The single-connection setup shared by `Vacuum`, `RebuildFTS`, `Checkpoint`,
+  and the private `checkpoint` is extracted into one `openSingleConn` helper.
+
+**Negative / trade-offs**
+
+- A full FTS5 rebuild is O(index size) and, under SQLCipher, re-encrypts the
+  rewritten pages — heavier than `--vacuum`. It is a manual/explicit operation,
+  not part of the auto-cleanup path.
+- On-disk truncation still depends on the deferred `Close()` checkpoint
+  (ADR-016): the CLI relies on its normal command teardown to flush the shrunk
+  file to disk.
+
+**Cross-reference**
+
+- ADR-011 / ADR-022 — cleanup and DB-bloat prevention; this ADR adds the FTS
+  reclamation path VACUUM-based bloat control did not cover.
+- ADR-016 — WAL + checkpoint; the dedicated single-connection pattern and
+  checkpoint-on-close invariant are reused here.
+- ADR-020 — the WAL/PRAGMA-rekey incompatibility applies only to rekey;
+  `rebuild` and `VACUUM` run safely in WAL mode.
+
+## CLI changes
+
+```
+capy cleanup --optimize           # rebuild FTS indexes + VACUUM to reclaim FTS bloat
+capy cleanup --force --optimize   # evict stale sources first, then reclaim
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -433,7 +433,7 @@ against the repository's **main worktree** so all worktrees share one committed 
 | `capy setup` | Configure capy for current project (Claude Code or Codex) |
 | `capy doctor` | Run diagnostics |
 | `capy which` | Print knowledge base path |
-| `capy cleanup` | Remove stale entries |
+| `capy cleanup` | Remove stale entries; `--vacuum` reclaims freelist pages, `--optimize` rebuilds FTS indexes + VACUUM to reclaim FTS tombstone bloat (ADR-029) |
 | `capy checkpoint` | Flush WAL into main DB file |
 | `capy encrypt` | Encrypt DB or rotate key |
 | `capy dbsize` | Show DB disk usage |

--- a/internal/store/optimize_test.go
+++ b/internal/store/optimize_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,78 @@ func TestOptimizeFTSDoesNotBreakSearch(t *testing.T) {
 	results, err := s.SearchWithFallback("authentication", 5, SearchOptions{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, results)
+}
+
+func TestRebuildFTSRunsAndPreservesSearch(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Index(
+		"# Authentication\n\nJWT token validation middleware handles auth via RS256.",
+		"auth-doc",
+		"markdown",
+		KindDurable,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, s.RebuildFTS())
+
+	// The full rebuild must not corrupt the index — search still returns hits.
+	results, err := s.SearchWithFallback("authentication", 5, SearchOptions{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, results, "search should still work after FTS rebuild")
+}
+
+func TestRebuildFTSReclaimsBloatVacuumAloneCannot(t *testing.T) {
+	// Run identical index+evict churn against two stores. One reclaims with
+	// VACUUM only; the other with RebuildFTS+VACUUM. Eviction leaves FTS
+	// delete-tombstone segments whose pages are live (owned by the FTS data
+	// tables), so VACUUM alone cannot reclaim them — only a rebuild releases
+	// them. The rebuilt store must therefore end up with strictly fewer pages.
+	churn := func(s *ContentStore) {
+		for i := range 60 {
+			body := strings.Repeat(fmt.Sprintf("authentication middleware token %d ", i), 200)
+			_, err := s.Index(body, fmt.Sprintf("bloat-%d", i), "", KindDurable)
+			require.NoError(t, err)
+		}
+		for i := range 60 {
+			_, err := s.EvictByLabel(fmt.Sprintf("bloat-%d", i), false)
+			require.NoError(t, err)
+		}
+	}
+
+	vacuumOnly := newTestStore(t)
+	churn(vacuumOnly)
+	require.NoError(t, vacuumOnly.Vacuum())
+
+	rebuilt := newTestStore(t)
+	churn(rebuilt)
+	require.NoError(t, rebuilt.RebuildFTS())
+	require.NoError(t, rebuilt.Vacuum())
+
+	vacuumOnlyPages := pageCount(t, vacuumOnly)
+	rebuiltPages := pageCount(t, rebuilt)
+	t.Logf("vacuum-only pages=%d, rebuild+vacuum pages=%d", vacuumOnlyPages, rebuiltPages)
+
+	// Guard against a vacuous pass: if the churn stopped producing tombstone
+	// bloat (e.g. an FTS5 behavior change), both stores would be tiny and the
+	// comparison meaningless. The vacuum-only store must retain measurable bloat.
+	require.Greater(t, vacuumOnlyPages, int64(100),
+		"vacuum-only store should retain measurable FTS tombstone bloat")
+	assert.Less(t, rebuiltPages, vacuumOnlyPages,
+		"RebuildFTS+VACUUM should reclaim FTS tombstone pages that VACUUM alone leaves behind")
+}
+
+// pageCount returns the logical page count of the store's database. Reading via
+// the pool connection reflects VACUUM's result immediately; the on-disk file is
+// only truncated once the pool closes and checkpoints (ADR-016), which the
+// cleanup command does via its deferred Close.
+func pageCount(t *testing.T, s *ContentStore) int64 {
+	t.Helper()
+	db, err := s.getDB()
+	require.NoError(t, err)
+	var n int64
+	require.NoError(t, db.QueryRow("PRAGMA page_count").Scan(&n))
+	return n
 }
 
 func TestOptimizeFTSCounterResetsAfterTrigger(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -374,21 +374,34 @@ func (s *ContentStore) Close() error {
 	return err
 }
 
+// openSingleConn opens a dedicated single-connection *sql.DB to the encrypted
+// database, separate from the pool. Maintenance operations (Vacuum, RebuildFTS,
+// Checkpoint, checkpoint) that must run outside the pool share this setup:
+// encryption key, WAL journal mode, the given busy timeout, and a hard cap of
+// one connection. Callers own the returned handle and must defer Close.
+func (s *ContentStore) openSingleConn(busyTimeoutMs int) (*sql.DB, error) {
+	key, err := RequireEncryptionKey()
+	if err != nil {
+		return nil, err
+	}
+	dsn := fmt.Sprintf("%s&_journal_mode=WAL&_busy_timeout=%d", EncryptedDSN(s.dbPath, key), busyTimeoutMs)
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
+}
+
 // checkpoint opens a dedicated single connection and runs
 // PRAGMA wal_checkpoint(TRUNCATE). Must be called after the
 // connection pool is closed so no other connections hold the WAL.
 func (s *ContentStore) checkpoint() error {
-	key, err := RequireEncryptionKey()
-	if err != nil {
-		return err
-	}
-	dsn := EncryptedDSN(s.dbPath, key) + "&_journal_mode=WAL&_busy_timeout=5000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := s.openSingleConn(5000)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
-	db.SetMaxOpenConns(1)
 	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 	return err
 }
@@ -406,20 +419,53 @@ func (s *ContentStore) optimizeFTS(db *sql.DB) {
 // dedicated single connection (not the pool) since VACUUM rewrites the entire
 // file — with SQLCipher this also re-encrypts, so it's heavier than plain SQLite.
 func (s *ContentStore) Vacuum() error {
-	key, err := RequireEncryptionKey()
-	if err != nil {
-		return err
-	}
-	dsn := EncryptedDSN(s.dbPath, key) + "&_journal_mode=WAL&_busy_timeout=10000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := s.openSingleConn(10000)
 	if err != nil {
 		return fmt.Errorf("opening database for vacuum: %w", err)
 	}
 	defer db.Close()
-	db.SetMaxOpenConns(1)
 
 	if _, err := db.Exec("VACUUM"); err != nil {
 		return fmt.Errorf("vacuum failed: %w", err)
+	}
+	return nil
+}
+
+// RebuildFTS fully reconstructs the FTS5 indexes (chunks, chunks_trigram) from
+// their content tables. Unlike the incremental 'optimize' merge that optimizeFTS
+// runs every optimizeEvery inserts, 'rebuild' discards accumulated delete-
+// tombstone segments left behind when sources are evicted. Those segments pin
+// disk pages that VACUUM cannot reclaim on its own — the freelist stays at 0
+// because the pages belong to the FTS5 data tables, not the free list. After a
+// rebuild the freed pages land on the freelist, so callers should follow with
+// Vacuum to actually shrink the file. Opens a dedicated single connection (not
+// the pool), mirroring Vacuum.
+func (s *ContentStore) RebuildFTS() error {
+	db, err := s.openSingleConn(10000)
+	if err != nil {
+		return fmt.Errorf("opening database for FTS rebuild: %w", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("INSERT INTO chunks(chunks) VALUES ('rebuild')"); err != nil {
+		return fmt.Errorf("rebuilding chunks FTS index: %w", err)
+	}
+	if _, err := db.Exec("INSERT INTO chunks_trigram(chunks_trigram) VALUES ('rebuild')"); err != nil {
+		return fmt.Errorf("rebuilding chunks_trigram FTS index: %w", err)
+	}
+	// Flush the rebuild out of the WAL so the freed pages are visible to the
+	// VACUUM that callers run next. Unlike Checkpoint, a busy result is
+	// tolerable rather than fatal here: when invoked after a cleanup pass the
+	// pool is still open, so TRUNCATE legitimately downgrades to PASSIVE. The
+	// subsequent VACUUM opens its own connection and rewrites the full logical
+	// DB (WAL frames included), so an incomplete checkpoint costs no
+	// reclamation — but it is worth surfacing.
+	var busy, logFrames, checkpointed int
+	if err := db.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &logFrames, &checkpointed); err != nil {
+		return fmt.Errorf("checkpointing WAL after FTS rebuild: %w", err)
+	}
+	if busy > 0 {
+		slog.Warn("WAL checkpoint incomplete after FTS rebuild (pool connections busy); VACUUM will still reclaim", "busy_pages", busy)
 	}
 	return nil
 }
@@ -444,19 +490,11 @@ func (s *ContentStore) FreelistRatio() float64 {
 // single connection (not the connection pool). This is the correct way to
 // checkpoint from outside the running server — e.g., from `capy checkpoint`.
 func (s *ContentStore) Checkpoint() error {
-	key, err := RequireEncryptionKey()
-	if err != nil {
-		return err
-	}
-	dsn := EncryptedDSN(s.dbPath, key) + "&_journal_mode=WAL&_busy_timeout=5000"
-	db, err := sql.Open("sqlite3", dsn)
+	db, err := s.openSingleConn(5000)
 	if err != nil {
 		return fmt.Errorf("opening database for checkpoint: %w", err)
 	}
 	defer db.Close()
-
-	// Force a single connection — no pool interference.
-	db.SetMaxOpenConns(1)
 
 	var busy, log, checkpointed int
 	err = db.QueryRow("PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &log, &checkpointed)


### PR DESCRIPTION


## Test Plan
n/a