### PR TITLE
Add `capy vault --path` flag to target a specific vault DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,17 +423,17 @@ Two archival paths populate the vault:
   0 9 * * *  CAPY_VAULT_KEY='…' /usr/local/bin/capy vault import
   ```
 
-Import is idempotent: unchanged sessions are skipped, grown sessions are updated in place, and a smaller (likely compacted) variant never overwrites a fuller archive. Use `--dry-run` to preview, `--project <substr>` to scope, `--path <dir>` to import from a non-default location.
+Import is idempotent: unchanged sessions are skipped, grown sessions are updated in place, and a smaller (likely compacted) variant never overwrites a fuller archive. Use `--dry-run` to preview, `--project <substr>` to scope, `--source <dir>` to import from a non-default location.
 
 > **Compaction:** `/compact` is append-only — it appends a summary entry and never rewrites earlier turns — so the full pre-compaction transcript stays in the session file, and the next startup sweep or `import` still archives it verbatim. The only residual risk is *deleting* the session file before it's been swept/imported. Import often to minimize that window.
 
 ### Commands
 
-All commands live under `capy vault` and require `CAPY_VAULT_KEY`. Lookups (`show`/`restore`/`resume`/`delete`) accept a **partial UUID of 8+ characters**, git-style; an ambiguous prefix prints candidates to disambiguate.
+All commands live under `capy vault` and require `CAPY_VAULT_KEY`. A persistent `--path <vault.db>` flag targets a specific vault file, overriding `CAPY_VAULT_PATH` and the XDG default. Lookups (`show`/`restore`/`resume`/`delete`) accept a **partial UUID of 8+ characters**, git-style; an ambiguous prefix prints candidates to disambiguate.
 
 | Command                                                                               | Description                                                                                                                                                                 |
 | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `import [--path <dir>] [--project <substr>] [--dry-run]`                              | Scan and archive sessions. Mutating by default.                                                                                                                             |
+| `import [--source <dir>] [--project <substr>] [--dry-run]`                            | Scan and archive sessions. Mutating by default.                                                                                                                             |
 | `reindex`                                                                             | Rebuild the search index for sessions archived by an older indexer (reads stored blobs, not disk; rewrites only the FTS index). Run once after upgrading capy.              |
 | `list [--project <substr>] [--limit N] [--json]`                                      | List sessions, newest first (`--limit` default 50, `0` = no limit).                                                                                                         |
 | `search <query> [--raw] [--project] [--role] [--after] [--before] [--limit] [--json]` | Full-text search with snippets. Plain keywords by default; `--raw` for FTS5 `MATCH` syntax. `--role user\|assistant\|tool\|system`; `--after`/`--before` take `YYYY-MM-DD`. |
@@ -502,7 +502,7 @@ capy vault rekey                     # enter the OLD passphrase when prompted
 
 ### Storage and limits
 
-- **Location:** `$XDG_DATA_HOME/capy/vault.db` (default `~/.local/share/capy/vault.db`). Override with `CAPY_VAULT_PATH`.
+- **Location:** `$XDG_DATA_HOME/capy/vault.db` (default `~/.local/share/capy/vault.db`). Override per-invocation with `--path`, or environment-wide with `CAPY_VAULT_PATH`.
 - **Encrypted at rest** with `CAPY_VAULT_KEY` (sqlite3mc / SQLCipher-compatible, same as the knowledge store). A different key cannot open the DB.
 - **Archives forever** — no TTL, no automatic cleanup. Reclaim space with `capy vault delete`. Expect ~50 MB/month for an active user; `stats` shows current size.
 - **Verbatim, not redacted.** `vault.db` concentrates every secret/credential/PII that appeared in any archived session, and `restore` writes them back as plaintext. This mirrors data that already lives unencrypted under `~/.claude/projects/` on the same host — but treat `vault.db` and its key accordingly. (Search snippets _are_ secret-stripped; the stored blobs are not.) A redacted-export pipeline is deferred to a future version.
@@ -512,7 +512,7 @@ capy vault rekey                     # enter the OLD passphrase when prompted
 | Variable            | Purpose                                                                           |
 | ------------------- | --------------------------------------------------------------------------------- |
 | `CAPY_VAULT_KEY`       | **Required.** Encryption passphrase for `vault.db` (separate from `CAPY_DB_KEY`).                                       |
-| `CAPY_VAULT_PATH`      | Override the vault database path.                                                                                      |
+| `CAPY_VAULT_PATH`      | Override the vault database path (the `--path` flag takes precedence per-invocation).                                  |
 | `CAPY_VAULT_SWEEP_ALL` | When set (any non-empty value), the MCP server startup sweep archives **all** projects, not just the current one.       |
 | `CAPY_VAULT_MERGE_KEY` | Default source-vault passphrase for `capy vault merge` (overridden by `--key`, falls back to `CAPY_VAULT_KEY`).         |
 | `CAPY_VAULT_NO_COMPRESS` | When set, store new blobs uncompressed (`encoding='raw'`); `capy vault compact` refuses to run. For debugging/benchmarking. |

--- a/cmd/capy/vault.go
+++ b/cmd/capy/vault.go
@@ -44,11 +44,18 @@ Requires CAPY_VAULT_KEY (the vault DB is encrypted at rest).`,
 			if _, err := vault.RequireVaultKey(); err != nil {
 				return err
 			}
-			env.dbPath = vault.VaultDBPath()
+			// --path overrides the CAPY_VAULT_PATH env / XDG default resolved by
+			// vault.VaultDBPath(). The flag is inherited by every subcommand.
+			if p, _ := cmd.Flags().GetString("path"); p != "" {
+				env.dbPath = p
+			} else {
+				env.dbPath = vault.VaultDBPath()
+			}
 			return nil
 		},
 	}
 
+	cmd.PersistentFlags().String("path", "", "vault DB file (default: CAPY_VAULT_PATH, else XDG data dir)")
 	cmd.PersistentFlags().Bool("tui", false, "interactive terminal UI (list, search, show)")
 
 	cmd.AddCommand(
@@ -75,7 +82,7 @@ Requires CAPY_VAULT_KEY (the vault DB is encrypted at rest).`,
 
 func newVaultImportCmd(env *vaultEnv) *cobra.Command {
 	var (
-		path    string
+		source  string
 		project string
 		dryRun  bool
 	)
@@ -88,7 +95,7 @@ The MCP server's startup sweep only archives the current project. Run
 'capy vault import' periodically (e.g. via cron) to capture sessions across
 all projects before Claude Code's 30-day cleanup removes them.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sessions, err := vault.DiscoverSessions(path)
+			sessions, err := vault.DiscoverSessions(source)
 			if err != nil {
 				return fmt.Errorf("discovering sessions: %w", err)
 			}
@@ -113,7 +120,7 @@ all projects before Claude Code's 30-day cleanup removes them.`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&path, "path", "", "source directory (default: Claude projects dir)")
+	cmd.Flags().StringVar(&source, "source", "", "source directory (default: Claude projects dir)")
 	cmd.Flags().StringVar(&project, "project", "", "only import sessions whose project dir matches this substring")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would be imported without writing")
 	return cmd

--- a/cmd/capy/vault_test.go
+++ b/cmd/capy/vault_test.go
@@ -16,7 +16,7 @@ import (
 const testVaultKey = "test-vault-cli-key-at-least-32-characters!!"
 
 // setupVaultEnv points the vault at a temp DB and writes one fixture session
-// under a single project directory. It returns the project root (for --path) and
+// under a single project directory. It returns the project root (for --source) and
 // the session UUID. Env vars flow to the `go run` subprocess via os.Environ().
 func setupVaultEnv(t *testing.T) (root, uuid string) {
 	t.Helper()
@@ -42,7 +42,7 @@ func TestVaultCommands_EndToEnd(t *testing.T) {
 	root, uuid := setupVaultEnv(t)
 	short := uuid[:8]
 
-	stdout, stderr, code := capy(t, "vault", "import", "--path", root)
+	stdout, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	assert.Contains(t, stdout, "imported 1")
 
@@ -78,9 +78,33 @@ func TestVaultCommands_EndToEnd(t *testing.T) {
 	assert.Contains(t, stdout, "WAL flushed")
 
 	// Re-import of an unchanged session is idempotent.
-	stdout, _, code = capy(t, "vault", "import", "--path", root)
+	stdout, _, code = capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code)
 	assert.Contains(t, stdout, "skipped 1")
+}
+
+// TestVaultPathFlag verifies the persistent --path flag overrides CAPY_VAULT_PATH:
+// the import lands in the --path DB, and a subsequent --path list finds it there
+// while the (untouched) env-path vault stays empty.
+func TestVaultPathFlag(t *testing.T) {
+	root, uuid := setupVaultEnv(t) // sets CAPY_VAULT_PATH to <dir>/vault.db
+	short := uuid[:8]
+
+	altDB := filepath.Join(t.TempDir(), "alt-vault.db")
+
+	stdout, stderr, code := capy(t, "vault", "import", "--source", root, "--path", altDB)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	assert.Contains(t, stdout, "imported 1")
+
+	// The session is in the --path DB...
+	stdout, _, code = capy(t, "vault", "list", "--path", altDB)
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, short)
+
+	// ...and not in the default (CAPY_VAULT_PATH) vault, which was never written.
+	stdout, _, code = capy(t, "vault", "list")
+	require.Equal(t, 0, code)
+	assert.Contains(t, stdout, "no sessions archived")
 }
 
 func TestVaultRequiresKey(t *testing.T) {
@@ -98,7 +122,7 @@ func TestVaultRequiresKey(t *testing.T) {
 // the internal/vault/tui package tests; it can't run here without a TTY.
 func TestVaultTUINotSupportedOnDestructive(t *testing.T) {
 	root, uuid := setupVaultEnv(t)
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	for _, sub := range []string{"restore", "resume", "delete"} {
@@ -123,7 +147,7 @@ func TestVaultRekeyNoVault(t *testing.T) {
 
 // setupVaultWithSidecar writes a fixture session that also has a subagent
 // sidecar so restore exercises vault_files. Returns the project root (for
-// --path), the uuid, and the raw main + sidecar bytes for verbatim diffing.
+// --source), the uuid, and the raw main + sidecar bytes for verbatim diffing.
 func setupVaultWithSidecar(t *testing.T) (root, uuid string, mainBytes, sidecarBytes []byte) {
 	t.Helper()
 	dir := t.TempDir()
@@ -152,7 +176,7 @@ func TestVaultRestoreToOutputDir(t *testing.T) {
 	root, uuid, mainBytes, sidecarBytes := setupVaultWithSidecar(t)
 	short := uuid[:8]
 
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	out := t.TempDir()
@@ -176,7 +200,7 @@ func TestVaultRestoreDefaultLocationHonorsConfigDir(t *testing.T) {
 	root, uuid, mainBytes, _ := setupVaultWithSidecar(t)
 	short := uuid[:8]
 
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	cfg := t.TempDir()
@@ -193,7 +217,7 @@ func TestVaultDeleteWithYes(t *testing.T) {
 	root, uuid := setupVaultEnv(t)
 	short := uuid[:8]
 
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	stdout, stderr, code := capy(t, "vault", "delete", short, "--yes")
@@ -216,7 +240,7 @@ func TestVaultDeleteAbortsWithoutConfirmation(t *testing.T) {
 	root, uuid := setupVaultEnv(t)
 	short := uuid[:8]
 
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	stdout, _, code := capy(t, "vault", "delete", short)
@@ -245,7 +269,7 @@ func TestVaultResumeLaunchesClaude(t *testing.T) {
 	}
 	root, uuid := setupVaultEnv(t)
 	short := uuid[:8]
-	_, stderr, code := capy(t, "vault", "import", "--path", root)
+	_, stderr, code := capy(t, "vault", "import", "--source", root)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir()) // restore lands here, not real ~/.claude
@@ -281,7 +305,7 @@ func TestVaultResumePropagatesExitCode(t *testing.T) {
 		t.Fatalf("build capy: %v\n%s", err, out)
 	}
 
-	imp := exec.Command(bin, "vault", "import", "--path", root)
+	imp := exec.Command(bin, "vault", "import", "--source", root)
 	imp.Env = os.Environ()
 	require.NoError(t, imp.Run(), "import via built binary")
 
@@ -327,12 +351,12 @@ func TestVaultMerge_EndToEnd(t *testing.T) {
 
 	// Build the source vault.
 	t.Setenv("CAPY_VAULT_PATH", srcVault)
-	_, stderr, code := capy(t, "vault", "import", "--path", srcProj)
+	_, stderr, code := capy(t, "vault", "import", "--source", srcProj)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	// Build the destination vault.
 	t.Setenv("CAPY_VAULT_PATH", destVault)
-	_, stderr, code = capy(t, "vault", "import", "--path", destProj)
+	_, stderr, code = capy(t, "vault", "import", "--source", destProj)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 
 	// Dry run writes nothing.


### PR DESCRIPTION
The vault DB location was only overridable environment-wide via
CAPY_VAULT_PATH. Add a persistent `--path` flag on the vault command
group so a single invocation can point at an arbitrary vault.db,
overriding both the env var and the XDG default. This makes ad-hoc
operations on a secondary vault (inspection, merge sources, backups)
possible without mutating the environment.

Rename `import`'s existing `--path` flag to `--source`: it meant the
source directory to scan for sessions, which now collides with the
group-level DB-path flag. This is a breaking change for scripts that
pass `capy vault import --path <dir>`.

Closes #78

## Test Plan
n/a